### PR TITLE
Add withOperationName for support named operation name

### DIFF
--- a/src/Graphql/Document.elm
+++ b/src/Graphql/Document.elm
@@ -16,11 +16,25 @@ import Json.Decode as Decode exposing (Decoder)
 import String.Interpolate exposing (interpolate)
 
 
+{-| append user define operationName.
+-}
+appendOperationName : String -> Maybe String -> String
+appendOperationName operation name =
+    name
+        |> Maybe.map (\name_ -> operation ++ " " ++ name_)
+        |> Maybe.withDefault operation
+
+
 {-| Serialize a query selection set into a string for a GraphQL endpoint.
 -}
-serializeQuery : SelectionSet decodesTo RootQuery -> String
-serializeQuery (SelectionSet fields decoder_) =
-    serialize "query" fields
+serializeQuery : Maybe String -> SelectionSet decodesTo RootQuery -> String
+serializeQuery operationName (SelectionSet fields decoder_) =
+    serialize
+        (appendOperationName
+            "query"
+            operationName
+        )
+        fields
 
 
 {-| Serialize a query selection set into a string with minimal whitespace. For
@@ -33,9 +47,14 @@ serializeQueryForUrl (SelectionSet fields decoder_) =
 
 {-| Serialize a mutation selection set into a string for a GraphQL endpoint.
 -}
-serializeMutation : SelectionSet decodesTo RootMutation -> String
-serializeMutation (SelectionSet fields decoder_) =
-    serialize "mutation" fields
+serializeMutation : Maybe String -> SelectionSet decodesTo RootMutation -> String
+serializeMutation operationName (SelectionSet fields decoder_) =
+    serialize
+        (appendOperationName
+            "mutation"
+            operationName
+        )
+        fields
 
 
 {-| Serialize a subscription selection set into a string for a GraphQL endpoint.

--- a/src/Graphql/Http.elm
+++ b/src/Graphql/Http.elm
@@ -28,7 +28,7 @@ The builder syntax is inspired by Luke Westby's
 
 ## Configure `Request` Options
 
-@docs withHeader, withTimeout, withCredentials, withQueryParams
+@docs withHeader, withTimeout, withCredentials, withQueryParams, withOperationName
 
 
 ## Perform `Request`

--- a/src/Graphql/Http.elm
+++ b/src/Graphql/Http.elm
@@ -384,7 +384,8 @@ withCredentials : Request decodesTo -> Request decodesTo
 withCredentials (Request request) =
     Request { request | withCredentials = True }
 
-
+{-| Set OperationName.
+-}
 withOperationName : String -> Request decodesTo -> Request decodesTo
 withOperationName operationName (Request request) =
     Request { request | operationName = Just operationName }

--- a/src/Graphql/Http.elm
+++ b/src/Graphql/Http.elm
@@ -5,6 +5,7 @@ module Graphql.Http exposing
     , withHeader, withTimeout, withCredentials, withQueryParams
     , send, toTask
     , mapError, ignoreParsedErrorData, fromHttpError
+    , withOperationName
     )
 
 {-| Send requests to your GraphQL endpoint. See [this live code demo](https://rebrand.ly/graphqelm)
@@ -65,6 +66,7 @@ type Request decodesTo
         , timeout : Maybe Float
         , withCredentials : Bool
         , queryParams : List ( String, String )
+        , operationName : Maybe String
         }
 
 
@@ -93,6 +95,7 @@ queryRequest baseUrl query =
     , withCredentials = False
     , details = Query Nothing query
     , queryParams = []
+    , operationName = Nothing
     }
         |> Request
 
@@ -123,6 +126,7 @@ queryRequestWithHttpGet baseUrl requestMethod query =
     , withCredentials = False
     , details = Query (Just requestMethod) query
     , queryParams = []
+    , operationName = Nothing
     }
         |> Request
 
@@ -139,6 +143,7 @@ mutationRequest baseUrl mutationSelectionSet =
     , timeout = Nothing
     , withCredentials = False
     , queryParams = []
+    , operationName = Nothing
     }
         |> Request
 
@@ -254,6 +259,7 @@ toRequest (Request request) =
                                 Just QueryHelper.Post
                         )
                         request.baseUrl
+                        request.operationName
                         request.queryParams
                         querySelectionSet
             in
@@ -280,7 +286,7 @@ toRequest (Request request) =
                 Http.jsonBody
                     (Json.Encode.object
                         [ ( "query"
-                          , Json.Encode.string (Document.serializeMutation mutationSelectionSet)
+                          , Json.Encode.string (Document.serializeMutation request.operationName mutationSelectionSet)
                           )
                         ]
                     )
@@ -377,3 +383,8 @@ withTimeout timeout (Request request) =
 withCredentials : Request decodesTo -> Request decodesTo
 withCredentials (Request request) =
     Request { request | withCredentials = True }
+
+
+withOperationName : String -> Request decodesTo -> Request decodesTo
+withOperationName operationName (Request request) =
+    Request { request | operationName = Just operationName }

--- a/src/Graphql/Http/QueryHelper.elm
+++ b/src/Graphql/Http/QueryHelper.elm
@@ -29,8 +29,8 @@ maxLength =
     2000
 
 
-build : Maybe HttpMethod -> String -> List QueryParam -> SelectionSet decodesTo RootQuery -> QueryRequest
-build forceMethod url queryParams queryDocument =
+build : Maybe HttpMethod -> String -> Maybe String -> List QueryParam -> SelectionSet decodesTo RootQuery -> QueryRequest
+build forceMethod url operationName queryParams queryDocument =
     let
         urlForGetRequest =
             QueryParams.urlWithQueryParams (queryParams ++ [ ( "query", Document.serializeQueryForUrl queryDocument ) ]) url
@@ -38,7 +38,7 @@ build forceMethod url queryParams queryDocument =
     if forceMethod == Just Post || (String.length urlForGetRequest >= maxLength && forceMethod /= Just Get) then
         { method = Post
         , url = QueryParams.urlWithQueryParams [] url
-        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery queryDocument) ) ])
+        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery operationName queryDocument) ) ])
         }
 
     else

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -26,7 +26,7 @@ all =
         [ test "single leaf" <|
             \() ->
                 document [ Leaf "avatar" [] ]
-                    |> Graphql.Document.serializeQuery
+                    |> Graphql.Document.serializeQuery Nothing
                     |> Expect.equal """query {
   avatar
 }"""
@@ -52,7 +52,7 @@ all =
                     [ Leaf "avatar" []
                     , Leaf "labels" []
                     ]
-                    |> Graphql.Document.serializeQuery
+                    |> Graphql.Document.serializeQuery Nothing
                     |> Expect.equal """query {
   avatar
   labels
@@ -63,7 +63,7 @@ all =
                     [ Leaf "avatar" []
                     , Leaf "avatar" []
                     ]
-                    |> Graphql.Document.serializeQuery
+                    |> Graphql.Document.serializeQuery Nothing
                     |> Expect.equal """query {
   avatar
   avatar
@@ -77,7 +77,7 @@ all =
                         , Leaf "avatar" []
                         ]
                     ]
-                    |> Graphql.Document.serializeQuery
+                    |> Graphql.Document.serializeQuery Nothing
                     |> Expect.equal """query {
   topLevel {
     avatar
@@ -92,7 +92,7 @@ all =
                         [ Composite "...on Droid" [] []
                         ]
                     ]
-                    |> Graphql.Document.serializeQuery
+                    |> Graphql.Document.serializeQuery Nothing
                     |> Expect.equal """query {
   topLevel {
     ...on Droid {
@@ -104,7 +104,7 @@ all =
             [ test "top-level empty query" <|
                 \() ->
                     document []
-                        |> Graphql.Document.serializeQuery
+                        |> Graphql.Document.serializeQuery Nothing
                         |> Expect.equal """query {
   __typename
 }"""
@@ -113,8 +113,19 @@ all =
                     document
                         [ Composite "viewer" [] []
                         ]
-                        |> Graphql.Document.serializeQuery
+                        |> Graphql.Document.serializeQuery Nothing
                         |> Expect.equal """query {
+  viewer {
+    __typename
+  }
+}"""
+            , test "named operation query" <|
+                \() ->
+                    document
+                        [ Composite "viewer" [] []
+                        ]
+                        |> Graphql.Document.serializeQuery (Just "namedOperation")
+                        |> Expect.equal """query namedOperation {
   viewer {
     __typename
   }

--- a/tests/Http/QueryHelperTests.elm
+++ b/tests/Http/QueryHelperTests.elm
@@ -33,7 +33,7 @@ all =
         [ test "uses GET when it is short enough" <|
             \() ->
                 document [ Composite "hero" [] [ Leaf "name" [] ] ]
-                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" []
+                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" [] Nothing
                     |> Expect.equal
                         { method = QueryHelper.Get
                         , url = "https://elm-graphql.herokuapp.com/api?query=%7Bhero%7Bname%7D%7D"
@@ -46,11 +46,11 @@ all =
                         document [ Composite "hero" [] [ Leaf "name" [] ] ]
                 in
                 queryDocument
-                    |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" []
+                    |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" [] Nothing
                     |> Expect.equal
                         { method = QueryHelper.Post
                         , url = "https://elm-graphql.herokuapp.com/api"
-                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery queryDocument) ) ])
+                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
                         }
         , test "uses POST when it too long" <|
             \() ->
@@ -65,10 +65,10 @@ all =
                             ]
                 in
                 queryDocument
-                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" []
+                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" [] Nothing
                     |> Expect.equal
                         { method = QueryHelper.Post
                         , url = "https://elm-graphql.herokuapp.com/api"
-                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery queryDocument) ) ])
+                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
                         }
         ]

--- a/tests/Http/QueryHelperTests.elm
+++ b/tests/Http/QueryHelperTests.elm
@@ -33,7 +33,7 @@ all =
         [ test "uses GET when it is short enough" <|
             \() ->
                 document [ Composite "hero" [] [ Leaf "name" [] ] ]
-                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" [] Nothing
+                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" Nothing []
                     |> Expect.equal
                         { method = QueryHelper.Get
                         , url = "https://elm-graphql.herokuapp.com/api?query=%7Bhero%7Bname%7D%7D"
@@ -45,13 +45,13 @@ all =
                     queryDocument =
                         document [ Composite "hero" [] [ Leaf "name" [] ] ]
                 in
-                queryDocument
-                    |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" [] Nothing
-                    |> Expect.equal
-                        { method = QueryHelper.Post
-                        , url = "https://elm-graphql.herokuapp.com/api"
-                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
-                        }
+                    queryDocument
+                        |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" Nothing []
+                        |> Expect.equal
+                            { method = QueryHelper.Post
+                            , url = "https://elm-graphql.herokuapp.com/api"
+                            , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
+                            }
         , test "uses POST when it too long" <|
             \() ->
                 let
@@ -64,11 +64,11 @@ all =
                                 ]
                             ]
                 in
-                queryDocument
-                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" [] Nothing
-                    |> Expect.equal
-                        { method = QueryHelper.Post
-                        , url = "https://elm-graphql.herokuapp.com/api"
-                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
-                        }
+                    queryDocument
+                        |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" Nothing []
+                        |> Expect.equal
+                            { method = QueryHelper.Post
+                            , url = "https://elm-graphql.herokuapp.com/api"
+                            , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
+                            }
         ]

--- a/tests/Http/QueryHelperTests.elm
+++ b/tests/Http/QueryHelperTests.elm
@@ -45,13 +45,13 @@ all =
                     queryDocument =
                         document [ Composite "hero" [] [ Leaf "name" [] ] ]
                 in
-                    queryDocument
-                        |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" Nothing []
-                        |> Expect.equal
-                            { method = QueryHelper.Post
-                            , url = "https://elm-graphql.herokuapp.com/api"
-                            , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
-                            }
+                queryDocument
+                    |> QueryHelper.build (Just QueryHelper.Post) "https://elm-graphql.herokuapp.com/api" Nothing []
+                    |> Expect.equal
+                       { method = QueryHelper.Post
+                       , url = "https://elm-graphql.herokuapp.com/api"
+                       , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
+                       }
         , test "uses POST when it too long" <|
             \() ->
                 let
@@ -64,11 +64,11 @@ all =
                                 ]
                             ]
                 in
-                    queryDocument
-                        |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" Nothing []
-                        |> Expect.equal
-                            { method = QueryHelper.Post
-                            , url = "https://elm-graphql.herokuapp.com/api"
-                            , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
-                            }
+                queryDocument
+                    |> QueryHelper.build Nothing "https://elm-graphql.herokuapp.com/api" Nothing []
+                    |> Expect.equal
+                        { method = QueryHelper.Post
+                        , url = "https://elm-graphql.herokuapp.com/api"
+                        , body = Http.jsonBody (Json.Encode.object [ ( "query", Json.Encode.string (Document.serializeQuery Nothing queryDocument) ) ])
+                        }
         ]


### PR DESCRIPTION
i want post query like this

```
query GetSomeThing {
  some {
    ..
  }
}
```

how to use public function
```
request
    |> withOperationName "GetSomeThing"
```
