### PR TITLE
Exhaustive fragments API

### DIFF
--- a/examples/src/Example03Variables.elm
+++ b/examples/src/Example03Variables.elm
@@ -1,0 +1,99 @@
+module Example03Variables exposing (main)
+
+import Browser
+import Graphql.Document as Document
+import Graphql.Field as Field
+import Graphql.Http
+import Graphql.Operation exposing (RootQuery)
+import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with, withFragment)
+import Html exposing (div, h1, p, pre, text)
+import PrintAny
+import RemoteData exposing (RemoteData)
+import Swapi.Enum.Episode as Episode exposing (Episode)
+import Swapi.Interface
+import Swapi.Interface.Character as Character
+import Swapi.Object
+import Swapi.Object.Droid as Droid
+import Swapi.Object.Human as Human
+import Swapi.Query as Query
+import Swapi.Scalar exposing (Id(..))
+
+
+type alias Response =
+    Maybe Human
+
+
+type alias Human =
+    { name : String
+    , homePlanet : Maybe String
+    }
+
+
+query : Id -> SelectionSet Response RootQuery
+query id =
+    Query.human { id = id }
+        (Human.selection Human
+            |> with Human.name
+            |> with Human.homePlanet
+        )
+        |> fieldSelection
+
+
+makeRequest : Cmd Msg
+makeRequest =
+    Id "1001"
+        |> query
+        |> Graphql.Http.queryRequest "https://elm-graphql.herokuapp.com"
+        |> Graphql.Http.withCredentials
+        |> Graphql.Http.send (RemoteData.fromResult >> GotResponse)
+
+
+type Msg
+    = GotResponse Model
+
+
+type alias Model =
+    RemoteData (Graphql.Http.Error Response) Response
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( RemoteData.Loading
+    , makeRequest
+    )
+
+
+view : Model -> Browser.Document Msg
+view model =
+    { title = "Starwars Demo"
+    , body =
+        [ div []
+            [ div []
+                [ h1 [] [ text "Generated Query" ]
+                , pre [] [ text (Document.serializeQuery (query (Id "1001"))) ]
+                ]
+            , div []
+                [ h1 [] [ text "Response" ]
+                , model |> PrintAny.view
+                ]
+            ]
+        ]
+    }
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GotResponse response ->
+            ( response, Cmd.none )
+
+
+main : Program () Model Msg
+main =
+    Browser.document
+        { init = init
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        , view = view
+        }

--- a/examples/src/Example04ErrorDestructuring.elm
+++ b/examples/src/Example04ErrorDestructuring.elm
@@ -4,6 +4,7 @@ import Browser
 import Graphql.Document as Document
 import Graphql.Field as Field
 import Graphql.Http
+import Graphql.Http.GraphqlError
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with, withFragment)
@@ -21,22 +22,12 @@ import Swapi.Scalar exposing (Id(..))
 
 
 type alias Response =
-    Maybe Human
-
-
-type alias Human =
-    { name : String
-    , homePlanet : Maybe String
-    }
+    Maybe String
 
 
 query : Id -> SelectionSet Response RootQuery
 query id =
-    Query.human { id = id }
-        (Human.selection Human
-            |> with Human.name
-            |> with Human.homePlanet
-        )
+    Query.forcedError
         |> fieldSelection
 
 
@@ -99,10 +90,17 @@ errorToString : Graphql.Http.Error parsedData -> String
 errorToString errorData =
     case errorData of
         Graphql.Http.GraphqlError _ graphqlErrors ->
-            "Error"
+            graphqlErrors
+                |> List.map graphqlErrorToString
+                |> String.join "\n"
 
         Graphql.Http.HttpError httpError ->
             "Http Error"
+
+
+graphqlErrorToString : Graphql.Http.GraphqlError.GraphqlError -> String
+graphqlErrorToString error =
+    error.message
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/examples/src/Example04ErrorDestructuring.elm
+++ b/examples/src/Example04ErrorDestructuring.elm
@@ -1,0 +1,122 @@
+module Example04ErrorDestructuring exposing (main)
+
+import Browser
+import Graphql.Document as Document
+import Graphql.Field as Field
+import Graphql.Http
+import Graphql.Operation exposing (RootQuery)
+import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with, withFragment)
+import Html exposing (Html, div, h1, p, pre, text)
+import PrintAny
+import RemoteData exposing (RemoteData)
+import Swapi.Enum.Episode as Episode exposing (Episode)
+import Swapi.Interface
+import Swapi.Interface.Character as Character
+import Swapi.Object
+import Swapi.Object.Droid as Droid
+import Swapi.Object.Human as Human
+import Swapi.Query as Query
+import Swapi.Scalar exposing (Id(..))
+
+
+type alias Response =
+    Maybe Human
+
+
+type alias Human =
+    { name : String
+    , homePlanet : Maybe String
+    }
+
+
+query : Id -> SelectionSet Response RootQuery
+query id =
+    Query.human { id = id }
+        (Human.selection Human
+            |> with Human.name
+            |> with Human.homePlanet
+        )
+        |> fieldSelection
+
+
+makeRequest : Cmd Msg
+makeRequest =
+    Id "1001"
+        |> query
+        |> Graphql.Http.queryRequest "https://elm-graphql.herokuapp.com"
+        |> Graphql.Http.withCredentials
+        |> Graphql.Http.send (RemoteData.fromResult >> GotResponse)
+
+
+type Msg
+    = GotResponse Model
+
+
+type alias Model =
+    RemoteData (Graphql.Http.Error Response) Response
+
+
+init : () -> ( Model, Cmd Msg )
+init _ =
+    ( RemoteData.Loading
+    , makeRequest
+    )
+
+
+view : Model -> Browser.Document Msg
+view model =
+    { title = "Starwars Demo"
+    , body =
+        [ div []
+            [ h1 [] [ text "Generated Query" ]
+            , pre [] [ text (Document.serializeQuery (query (Id "1001"))) ]
+            ]
+        , case model of
+            RemoteData.Success successData ->
+                successView successData
+
+            RemoteData.Failure errorData ->
+                errorData
+                    |> errorToString
+                    |> text
+
+            _ ->
+                text "Loading..."
+        ]
+    }
+
+
+successView : Response -> Html Msg
+successView successData =
+    div []
+        [ h1 [] [ text "Response" ]
+        , successData |> PrintAny.view
+        ]
+
+
+errorToString : Graphql.Http.Error parsedData -> String
+errorToString errorData =
+    case errorData of
+        Graphql.Http.GraphqlError _ graphqlErrors ->
+            "Error"
+
+        Graphql.Http.HttpError httpError ->
+            "Http Error"
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GotResponse response ->
+            ( response, Cmd.none )
+
+
+main : Program () Model Msg
+main =
+    Browser.document
+        { init = init
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        , view = view
+        }

--- a/examples/src/Github/Interface/Deletable.elm
+++ b/examples/src/Github/Interface/Deletable.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.Deletable exposing (commonSelection, onCommitComment, onGistComment, onIssueComment, onPullRequestReview, onPullRequestReviewComment, selection, viewerCanDelete)
+module Github.Interface.Deletable exposing (Fragments, fragments, maybeFragments, selection, viewerCanDelete)
 
 import Github.InputObject
 import Github.Interface
@@ -19,43 +19,48 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Deletable
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Deletable
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onCommitComment : SelectionSet decodesTo Github.Object.CommitComment
+    , onGistComment : SelectionSet decodesTo Github.Object.GistComment
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.Deletable) -> SelectionSet (a -> constructor) Github.Interface.Deletable
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.Deletable
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "CommitComment" selections.onCommitComment
+        , Object.buildFragment "GistComment" selections.onGistComment
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        ]
 
 
-onCommitComment : SelectionSet decodesTo Github.Object.CommitComment -> FragmentSelectionSet decodesTo Github.Interface.Deletable
-onCommitComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitComment" fields decoder
-
-
-onGistComment : SelectionSet decodesTo Github.Object.GistComment -> FragmentSelectionSet decodesTo Github.Interface.Deletable
-onGistComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "GistComment" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Interface.Deletable
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Interface.Deletable
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Interface.Deletable
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommitComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onGistComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| Check if the current viewer can delete this object.

--- a/examples/src/Github/Interface/Labelable.elm
+++ b/examples/src/Github/Interface/Labelable.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.Labelable exposing (LabelsOptionalArguments, commonSelection, labels, onIssue, onPullRequest, selection)
+module Github.Interface.Labelable exposing (Fragments, LabelsOptionalArguments, fragments, labels, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -19,28 +19,39 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Labelable
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Labelable
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.Labelable) -> SelectionSet (a -> constructor) Github.Interface.Labelable
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.Labelable
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.Labelable
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.Labelable
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 type alias LabelsOptionalArguments =

--- a/examples/src/Github/Interface/Lockable.elm
+++ b/examples/src/Github/Interface/Lockable.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.Lockable exposing (activeLockReason, commonSelection, locked, onIssue, onPullRequest, selection)
+module Github.Interface.Lockable exposing (Fragments, activeLockReason, fragments, locked, maybeFragments, selection)
 
 import Github.Enum.LockReason
 import Github.InputObject
@@ -20,28 +20,39 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Lockable
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Lockable
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.Lockable) -> SelectionSet (a -> constructor) Github.Interface.Lockable
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.Lockable
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.Lockable
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.Lockable
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| Reason that the conversation was locked.

--- a/examples/src/Github/Interface/Node.elm
+++ b/examples/src/Github/Interface/Node.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.Node exposing (commonSelection, id, onAddedToProjectEvent, onAssignedEvent, onBaseRefChangedEvent, onBaseRefForcePushedEvent, onBlob, onBot, onClosedEvent, onCommentDeletedEvent, onCommit, onCommitComment, onCommitCommentThread, onConvertedNoteToIssueEvent, onCrossReferencedEvent, onDemilestonedEvent, onDeployKey, onDeployedEvent, onDeployment, onDeploymentStatus, onExternalIdentity, onGist, onGistComment, onHeadRefDeletedEvent, onHeadRefForcePushedEvent, onHeadRefRestoredEvent, onIssue, onIssueComment, onLabel, onLabeledEvent, onLanguage, onLockedEvent, onMarketplaceListing, onMentionedEvent, onMergedEvent, onMilestone, onMilestonedEvent, onMovedColumnsInProjectEvent, onOrganization, onOrganizationIdentityProvider, onOrganizationInvitation, onProject, onProjectCard, onProjectColumn, onProtectedBranch, onPublicKey, onPullRequest, onPullRequestCommit, onPullRequestReview, onPullRequestReviewComment, onPullRequestReviewThread, onPushAllowance, onReaction, onRef, onReferencedEvent, onRelease, onReleaseAsset, onRemovedFromProjectEvent, onRenamedTitleEvent, onReopenedEvent, onRepository, onRepositoryInvitation, onRepositoryTopic, onReviewDismissalAllowance, onReviewDismissedEvent, onReviewRequest, onReviewRequestRemovedEvent, onReviewRequestedEvent, onStatus, onStatusContext, onSubscribedEvent, onTag, onTeam, onTopic, onTree, onUnassignedEvent, onUnlabeledEvent, onUnlockedEvent, onUnsubscribedEvent, onUser, onUserContentEdit, selection)
+module Github.Interface.Node exposing (Fragments, fragments, id, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -19,413 +19,270 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Node
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Node
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onAddedToProjectEvent : SelectionSet decodesTo Github.Object.AddedToProjectEvent
+    , onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent
+    , onBaseRefChangedEvent : SelectionSet decodesTo Github.Object.BaseRefChangedEvent
+    , onBaseRefForcePushedEvent : SelectionSet decodesTo Github.Object.BaseRefForcePushedEvent
+    , onBlob : SelectionSet decodesTo Github.Object.Blob
+    , onBot : SelectionSet decodesTo Github.Object.Bot
+    , onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent
+    , onCommentDeletedEvent : SelectionSet decodesTo Github.Object.CommentDeletedEvent
+    , onCommit : SelectionSet decodesTo Github.Object.Commit
+    , onCommitComment : SelectionSet decodesTo Github.Object.CommitComment
+    , onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread
+    , onConvertedNoteToIssueEvent : SelectionSet decodesTo Github.Object.ConvertedNoteToIssueEvent
+    , onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent
+    , onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent
+    , onDeployKey : SelectionSet decodesTo Github.Object.DeployKey
+    , onDeployedEvent : SelectionSet decodesTo Github.Object.DeployedEvent
+    , onDeployment : SelectionSet decodesTo Github.Object.Deployment
+    , onDeploymentStatus : SelectionSet decodesTo Github.Object.DeploymentStatus
+    , onExternalIdentity : SelectionSet decodesTo Github.Object.ExternalIdentity
+    , onGist : SelectionSet decodesTo Github.Object.Gist
+    , onGistComment : SelectionSet decodesTo Github.Object.GistComment
+    , onHeadRefDeletedEvent : SelectionSet decodesTo Github.Object.HeadRefDeletedEvent
+    , onHeadRefForcePushedEvent : SelectionSet decodesTo Github.Object.HeadRefForcePushedEvent
+    , onHeadRefRestoredEvent : SelectionSet decodesTo Github.Object.HeadRefRestoredEvent
+    , onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onLabel : SelectionSet decodesTo Github.Object.Label
+    , onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent
+    , onLanguage : SelectionSet decodesTo Github.Object.Language
+    , onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent
+    , onMarketplaceListing : SelectionSet decodesTo Github.Object.MarketplaceListing
+    , onMentionedEvent : SelectionSet decodesTo Github.Object.MentionedEvent
+    , onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent
+    , onMilestone : SelectionSet decodesTo Github.Object.Milestone
+    , onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent
+    , onMovedColumnsInProjectEvent : SelectionSet decodesTo Github.Object.MovedColumnsInProjectEvent
+    , onOrganization : SelectionSet decodesTo Github.Object.Organization
+    , onOrganizationIdentityProvider : SelectionSet decodesTo Github.Object.OrganizationIdentityProvider
+    , onOrganizationInvitation : SelectionSet decodesTo Github.Object.OrganizationInvitation
+    , onProject : SelectionSet decodesTo Github.Object.Project
+    , onProjectCard : SelectionSet decodesTo Github.Object.ProjectCard
+    , onProjectColumn : SelectionSet decodesTo Github.Object.ProjectColumn
+    , onProtectedBranch : SelectionSet decodesTo Github.Object.ProtectedBranch
+    , onPublicKey : SelectionSet decodesTo Github.Object.PublicKey
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    , onPullRequestCommit : SelectionSet decodesTo Github.Object.PullRequestCommit
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    , onPullRequestReviewThread : SelectionSet decodesTo Github.Object.PullRequestReviewThread
+    , onPushAllowance : SelectionSet decodesTo Github.Object.PushAllowance
+    , onReaction : SelectionSet decodesTo Github.Object.Reaction
+    , onRef : SelectionSet decodesTo Github.Object.Ref
+    , onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent
+    , onRelease : SelectionSet decodesTo Github.Object.Release
+    , onReleaseAsset : SelectionSet decodesTo Github.Object.ReleaseAsset
+    , onRemovedFromProjectEvent : SelectionSet decodesTo Github.Object.RemovedFromProjectEvent
+    , onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent
+    , onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent
+    , onRepository : SelectionSet decodesTo Github.Object.Repository
+    , onRepositoryInvitation : SelectionSet decodesTo Github.Object.RepositoryInvitation
+    , onRepositoryTopic : SelectionSet decodesTo Github.Object.RepositoryTopic
+    , onReviewDismissalAllowance : SelectionSet decodesTo Github.Object.ReviewDismissalAllowance
+    , onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent
+    , onReviewRequest : SelectionSet decodesTo Github.Object.ReviewRequest
+    , onReviewRequestRemovedEvent : SelectionSet decodesTo Github.Object.ReviewRequestRemovedEvent
+    , onReviewRequestedEvent : SelectionSet decodesTo Github.Object.ReviewRequestedEvent
+    , onStatus : SelectionSet decodesTo Github.Object.Status
+    , onStatusContext : SelectionSet decodesTo Github.Object.StatusContext
+    , onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent
+    , onTag : SelectionSet decodesTo Github.Object.Tag
+    , onTeam : SelectionSet decodesTo Github.Object.Team
+    , onTopic : SelectionSet decodesTo Github.Object.Topic
+    , onTree : SelectionSet decodesTo Github.Object.Tree
+    , onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent
+    , onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent
+    , onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent
+    , onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent
+    , onUser : SelectionSet decodesTo Github.Object.User
+    , onUserContentEdit : SelectionSet decodesTo Github.Object.UserContentEdit
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.Node) -> SelectionSet (a -> constructor) Github.Interface.Node
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
-
-
-onAddedToProjectEvent : SelectionSet decodesTo Github.Object.AddedToProjectEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onAddedToProjectEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "AddedToProjectEvent" fields decoder
-
-
-onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onAssignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "AssignedEvent" fields decoder
-
-
-onBaseRefChangedEvent : SelectionSet decodesTo Github.Object.BaseRefChangedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onBaseRefChangedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "BaseRefChangedEvent" fields decoder
-
-
-onBaseRefForcePushedEvent : SelectionSet decodesTo Github.Object.BaseRefForcePushedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onBaseRefForcePushedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "BaseRefForcePushedEvent" fields decoder
-
-
-onBlob : SelectionSet decodesTo Github.Object.Blob -> FragmentSelectionSet decodesTo Github.Interface.Node
-onBlob (SelectionSet fields decoder) =
-    FragmentSelectionSet "Blob" fields decoder
-
-
-onBot : SelectionSet decodesTo Github.Object.Bot -> FragmentSelectionSet decodesTo Github.Interface.Node
-onBot (SelectionSet fields decoder) =
-    FragmentSelectionSet "Bot" fields decoder
-
-
-onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onClosedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ClosedEvent" fields decoder
-
-
-onCommentDeletedEvent : SelectionSet decodesTo Github.Object.CommentDeletedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onCommentDeletedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommentDeletedEvent" fields decoder
-
-
-onCommit : SelectionSet decodesTo Github.Object.Commit -> FragmentSelectionSet decodesTo Github.Interface.Node
-onCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "Commit" fields decoder
-
-
-onCommitComment : SelectionSet decodesTo Github.Object.CommitComment -> FragmentSelectionSet decodesTo Github.Interface.Node
-onCommitComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitComment" fields decoder
-
-
-onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread -> FragmentSelectionSet decodesTo Github.Interface.Node
-onCommitCommentThread (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitCommentThread" fields decoder
-
-
-onConvertedNoteToIssueEvent : SelectionSet decodesTo Github.Object.ConvertedNoteToIssueEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onConvertedNoteToIssueEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ConvertedNoteToIssueEvent" fields decoder
-
-
-onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onCrossReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "CrossReferencedEvent" fields decoder
-
-
-onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onDemilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "DemilestonedEvent" fields decoder
-
-
-onDeployKey : SelectionSet decodesTo Github.Object.DeployKey -> FragmentSelectionSet decodesTo Github.Interface.Node
-onDeployKey (SelectionSet fields decoder) =
-    FragmentSelectionSet "DeployKey" fields decoder
-
-
-onDeployedEvent : SelectionSet decodesTo Github.Object.DeployedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onDeployedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "DeployedEvent" fields decoder
-
-
-onDeployment : SelectionSet decodesTo Github.Object.Deployment -> FragmentSelectionSet decodesTo Github.Interface.Node
-onDeployment (SelectionSet fields decoder) =
-    FragmentSelectionSet "Deployment" fields decoder
-
-
-onDeploymentStatus : SelectionSet decodesTo Github.Object.DeploymentStatus -> FragmentSelectionSet decodesTo Github.Interface.Node
-onDeploymentStatus (SelectionSet fields decoder) =
-    FragmentSelectionSet "DeploymentStatus" fields decoder
-
-
-onExternalIdentity : SelectionSet decodesTo Github.Object.ExternalIdentity -> FragmentSelectionSet decodesTo Github.Interface.Node
-onExternalIdentity (SelectionSet fields decoder) =
-    FragmentSelectionSet "ExternalIdentity" fields decoder
-
-
-onGist : SelectionSet decodesTo Github.Object.Gist -> FragmentSelectionSet decodesTo Github.Interface.Node
-onGist (SelectionSet fields decoder) =
-    FragmentSelectionSet "Gist" fields decoder
-
-
-onGistComment : SelectionSet decodesTo Github.Object.GistComment -> FragmentSelectionSet decodesTo Github.Interface.Node
-onGistComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "GistComment" fields decoder
-
-
-onHeadRefDeletedEvent : SelectionSet decodesTo Github.Object.HeadRefDeletedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onHeadRefDeletedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefDeletedEvent" fields decoder
-
-
-onHeadRefForcePushedEvent : SelectionSet decodesTo Github.Object.HeadRefForcePushedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onHeadRefForcePushedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefForcePushedEvent" fields decoder
-
-
-onHeadRefRestoredEvent : SelectionSet decodesTo Github.Object.HeadRefRestoredEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onHeadRefRestoredEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefRestoredEvent" fields decoder
-
-
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.Node
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Interface.Node
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onLabel : SelectionSet decodesTo Github.Object.Label -> FragmentSelectionSet decodesTo Github.Interface.Node
-onLabel (SelectionSet fields decoder) =
-    FragmentSelectionSet "Label" fields decoder
-
-
-onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onLabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LabeledEvent" fields decoder
-
-
-onLanguage : SelectionSet decodesTo Github.Object.Language -> FragmentSelectionSet decodesTo Github.Interface.Node
-onLanguage (SelectionSet fields decoder) =
-    FragmentSelectionSet "Language" fields decoder
-
-
-onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onLockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LockedEvent" fields decoder
-
-
-onMarketplaceListing : SelectionSet decodesTo Github.Object.MarketplaceListing -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMarketplaceListing (SelectionSet fields decoder) =
-    FragmentSelectionSet "MarketplaceListing" fields decoder
-
-
-onMentionedEvent : SelectionSet decodesTo Github.Object.MentionedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMentionedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MentionedEvent" fields decoder
-
-
-onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMergedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MergedEvent" fields decoder
-
-
-onMilestone : SelectionSet decodesTo Github.Object.Milestone -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMilestone (SelectionSet fields decoder) =
-    FragmentSelectionSet "Milestone" fields decoder
-
-
-onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MilestonedEvent" fields decoder
-
-
-onMovedColumnsInProjectEvent : SelectionSet decodesTo Github.Object.MovedColumnsInProjectEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onMovedColumnsInProjectEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MovedColumnsInProjectEvent" fields decoder
-
-
-onOrganization : SelectionSet decodesTo Github.Object.Organization -> FragmentSelectionSet decodesTo Github.Interface.Node
-onOrganization (SelectionSet fields decoder) =
-    FragmentSelectionSet "Organization" fields decoder
-
-
-onOrganizationIdentityProvider : SelectionSet decodesTo Github.Object.OrganizationIdentityProvider -> FragmentSelectionSet decodesTo Github.Interface.Node
-onOrganizationIdentityProvider (SelectionSet fields decoder) =
-    FragmentSelectionSet "OrganizationIdentityProvider" fields decoder
-
-
-onOrganizationInvitation : SelectionSet decodesTo Github.Object.OrganizationInvitation -> FragmentSelectionSet decodesTo Github.Interface.Node
-onOrganizationInvitation (SelectionSet fields decoder) =
-    FragmentSelectionSet "OrganizationInvitation" fields decoder
-
-
-onProject : SelectionSet decodesTo Github.Object.Project -> FragmentSelectionSet decodesTo Github.Interface.Node
-onProject (SelectionSet fields decoder) =
-    FragmentSelectionSet "Project" fields decoder
-
-
-onProjectCard : SelectionSet decodesTo Github.Object.ProjectCard -> FragmentSelectionSet decodesTo Github.Interface.Node
-onProjectCard (SelectionSet fields decoder) =
-    FragmentSelectionSet "ProjectCard" fields decoder
-
-
-onProjectColumn : SelectionSet decodesTo Github.Object.ProjectColumn -> FragmentSelectionSet decodesTo Github.Interface.Node
-onProjectColumn (SelectionSet fields decoder) =
-    FragmentSelectionSet "ProjectColumn" fields decoder
-
-
-onProtectedBranch : SelectionSet decodesTo Github.Object.ProtectedBranch -> FragmentSelectionSet decodesTo Github.Interface.Node
-onProtectedBranch (SelectionSet fields decoder) =
-    FragmentSelectionSet "ProtectedBranch" fields decoder
-
-
-onPublicKey : SelectionSet decodesTo Github.Object.PublicKey -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPublicKey (SelectionSet fields decoder) =
-    FragmentSelectionSet "PublicKey" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
-
-
-onPullRequestCommit : SelectionSet decodesTo Github.Object.PullRequestCommit -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPullRequestCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestCommit" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
-
-
-onPullRequestReviewThread : SelectionSet decodesTo Github.Object.PullRequestReviewThread -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPullRequestReviewThread (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewThread" fields decoder
-
-
-onPushAllowance : SelectionSet decodesTo Github.Object.PushAllowance -> FragmentSelectionSet decodesTo Github.Interface.Node
-onPushAllowance (SelectionSet fields decoder) =
-    FragmentSelectionSet "PushAllowance" fields decoder
-
-
-onReaction : SelectionSet decodesTo Github.Object.Reaction -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReaction (SelectionSet fields decoder) =
-    FragmentSelectionSet "Reaction" fields decoder
-
-
-onRef : SelectionSet decodesTo Github.Object.Ref -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRef (SelectionSet fields decoder) =
-    FragmentSelectionSet "Ref" fields decoder
-
-
-onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReferencedEvent" fields decoder
-
-
-onRelease : SelectionSet decodesTo Github.Object.Release -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRelease (SelectionSet fields decoder) =
-    FragmentSelectionSet "Release" fields decoder
-
-
-onReleaseAsset : SelectionSet decodesTo Github.Object.ReleaseAsset -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReleaseAsset (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReleaseAsset" fields decoder
-
-
-onRemovedFromProjectEvent : SelectionSet decodesTo Github.Object.RemovedFromProjectEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRemovedFromProjectEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "RemovedFromProjectEvent" fields decoder
-
-
-onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRenamedTitleEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "RenamedTitleEvent" fields decoder
-
-
-onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReopenedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReopenedEvent" fields decoder
-
-
-onRepository : SelectionSet decodesTo Github.Object.Repository -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRepository (SelectionSet fields decoder) =
-    FragmentSelectionSet "Repository" fields decoder
-
-
-onRepositoryInvitation : SelectionSet decodesTo Github.Object.RepositoryInvitation -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRepositoryInvitation (SelectionSet fields decoder) =
-    FragmentSelectionSet "RepositoryInvitation" fields decoder
-
-
-onRepositoryTopic : SelectionSet decodesTo Github.Object.RepositoryTopic -> FragmentSelectionSet decodesTo Github.Interface.Node
-onRepositoryTopic (SelectionSet fields decoder) =
-    FragmentSelectionSet "RepositoryTopic" fields decoder
-
-
-onReviewDismissalAllowance : SelectionSet decodesTo Github.Object.ReviewDismissalAllowance -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReviewDismissalAllowance (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewDismissalAllowance" fields decoder
-
-
-onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReviewDismissedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewDismissedEvent" fields decoder
-
-
-onReviewRequest : SelectionSet decodesTo Github.Object.ReviewRequest -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReviewRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewRequest" fields decoder
-
-
-onReviewRequestRemovedEvent : SelectionSet decodesTo Github.Object.ReviewRequestRemovedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReviewRequestRemovedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewRequestRemovedEvent" fields decoder
-
-
-onReviewRequestedEvent : SelectionSet decodesTo Github.Object.ReviewRequestedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onReviewRequestedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewRequestedEvent" fields decoder
-
-
-onStatus : SelectionSet decodesTo Github.Object.Status -> FragmentSelectionSet decodesTo Github.Interface.Node
-onStatus (SelectionSet fields decoder) =
-    FragmentSelectionSet "Status" fields decoder
-
-
-onStatusContext : SelectionSet decodesTo Github.Object.StatusContext -> FragmentSelectionSet decodesTo Github.Interface.Node
-onStatusContext (SelectionSet fields decoder) =
-    FragmentSelectionSet "StatusContext" fields decoder
-
-
-onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onSubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "SubscribedEvent" fields decoder
-
-
-onTag : SelectionSet decodesTo Github.Object.Tag -> FragmentSelectionSet decodesTo Github.Interface.Node
-onTag (SelectionSet fields decoder) =
-    FragmentSelectionSet "Tag" fields decoder
-
-
-onTeam : SelectionSet decodesTo Github.Object.Team -> FragmentSelectionSet decodesTo Github.Interface.Node
-onTeam (SelectionSet fields decoder) =
-    FragmentSelectionSet "Team" fields decoder
-
-
-onTopic : SelectionSet decodesTo Github.Object.Topic -> FragmentSelectionSet decodesTo Github.Interface.Node
-onTopic (SelectionSet fields decoder) =
-    FragmentSelectionSet "Topic" fields decoder
-
-
-onTree : SelectionSet decodesTo Github.Object.Tree -> FragmentSelectionSet decodesTo Github.Interface.Node
-onTree (SelectionSet fields decoder) =
-    FragmentSelectionSet "Tree" fields decoder
-
-
-onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUnassignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnassignedEvent" fields decoder
-
-
-onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUnlabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlabeledEvent" fields decoder
-
-
-onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUnlockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlockedEvent" fields decoder
-
-
-onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUnsubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnsubscribedEvent" fields decoder
-
-
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
-
-
-onUserContentEdit : SelectionSet decodesTo Github.Object.UserContentEdit -> FragmentSelectionSet decodesTo Github.Interface.Node
-onUserContentEdit (SelectionSet fields decoder) =
-    FragmentSelectionSet "UserContentEdit" fields decoder
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.Node
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "AddedToProjectEvent" selections.onAddedToProjectEvent
+        , Object.buildFragment "AssignedEvent" selections.onAssignedEvent
+        , Object.buildFragment "BaseRefChangedEvent" selections.onBaseRefChangedEvent
+        , Object.buildFragment "BaseRefForcePushedEvent" selections.onBaseRefForcePushedEvent
+        , Object.buildFragment "Blob" selections.onBlob
+        , Object.buildFragment "Bot" selections.onBot
+        , Object.buildFragment "ClosedEvent" selections.onClosedEvent
+        , Object.buildFragment "CommentDeletedEvent" selections.onCommentDeletedEvent
+        , Object.buildFragment "Commit" selections.onCommit
+        , Object.buildFragment "CommitComment" selections.onCommitComment
+        , Object.buildFragment "CommitCommentThread" selections.onCommitCommentThread
+        , Object.buildFragment "ConvertedNoteToIssueEvent" selections.onConvertedNoteToIssueEvent
+        , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
+        , Object.buildFragment "DemilestonedEvent" selections.onDemilestonedEvent
+        , Object.buildFragment "DeployKey" selections.onDeployKey
+        , Object.buildFragment "DeployedEvent" selections.onDeployedEvent
+        , Object.buildFragment "Deployment" selections.onDeployment
+        , Object.buildFragment "DeploymentStatus" selections.onDeploymentStatus
+        , Object.buildFragment "ExternalIdentity" selections.onExternalIdentity
+        , Object.buildFragment "Gist" selections.onGist
+        , Object.buildFragment "GistComment" selections.onGistComment
+        , Object.buildFragment "HeadRefDeletedEvent" selections.onHeadRefDeletedEvent
+        , Object.buildFragment "HeadRefForcePushedEvent" selections.onHeadRefForcePushedEvent
+        , Object.buildFragment "HeadRefRestoredEvent" selections.onHeadRefRestoredEvent
+        , Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "Label" selections.onLabel
+        , Object.buildFragment "LabeledEvent" selections.onLabeledEvent
+        , Object.buildFragment "Language" selections.onLanguage
+        , Object.buildFragment "LockedEvent" selections.onLockedEvent
+        , Object.buildFragment "MarketplaceListing" selections.onMarketplaceListing
+        , Object.buildFragment "MentionedEvent" selections.onMentionedEvent
+        , Object.buildFragment "MergedEvent" selections.onMergedEvent
+        , Object.buildFragment "Milestone" selections.onMilestone
+        , Object.buildFragment "MilestonedEvent" selections.onMilestonedEvent
+        , Object.buildFragment "MovedColumnsInProjectEvent" selections.onMovedColumnsInProjectEvent
+        , Object.buildFragment "Organization" selections.onOrganization
+        , Object.buildFragment "OrganizationIdentityProvider" selections.onOrganizationIdentityProvider
+        , Object.buildFragment "OrganizationInvitation" selections.onOrganizationInvitation
+        , Object.buildFragment "Project" selections.onProject
+        , Object.buildFragment "ProjectCard" selections.onProjectCard
+        , Object.buildFragment "ProjectColumn" selections.onProjectColumn
+        , Object.buildFragment "ProtectedBranch" selections.onProtectedBranch
+        , Object.buildFragment "PublicKey" selections.onPublicKey
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        , Object.buildFragment "PullRequestCommit" selections.onPullRequestCommit
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        , Object.buildFragment "PullRequestReviewThread" selections.onPullRequestReviewThread
+        , Object.buildFragment "PushAllowance" selections.onPushAllowance
+        , Object.buildFragment "Reaction" selections.onReaction
+        , Object.buildFragment "Ref" selections.onRef
+        , Object.buildFragment "ReferencedEvent" selections.onReferencedEvent
+        , Object.buildFragment "Release" selections.onRelease
+        , Object.buildFragment "ReleaseAsset" selections.onReleaseAsset
+        , Object.buildFragment "RemovedFromProjectEvent" selections.onRemovedFromProjectEvent
+        , Object.buildFragment "RenamedTitleEvent" selections.onRenamedTitleEvent
+        , Object.buildFragment "ReopenedEvent" selections.onReopenedEvent
+        , Object.buildFragment "Repository" selections.onRepository
+        , Object.buildFragment "RepositoryInvitation" selections.onRepositoryInvitation
+        , Object.buildFragment "RepositoryTopic" selections.onRepositoryTopic
+        , Object.buildFragment "ReviewDismissalAllowance" selections.onReviewDismissalAllowance
+        , Object.buildFragment "ReviewDismissedEvent" selections.onReviewDismissedEvent
+        , Object.buildFragment "ReviewRequest" selections.onReviewRequest
+        , Object.buildFragment "ReviewRequestRemovedEvent" selections.onReviewRequestRemovedEvent
+        , Object.buildFragment "ReviewRequestedEvent" selections.onReviewRequestedEvent
+        , Object.buildFragment "Status" selections.onStatus
+        , Object.buildFragment "StatusContext" selections.onStatusContext
+        , Object.buildFragment "SubscribedEvent" selections.onSubscribedEvent
+        , Object.buildFragment "Tag" selections.onTag
+        , Object.buildFragment "Team" selections.onTeam
+        , Object.buildFragment "Topic" selections.onTopic
+        , Object.buildFragment "Tree" selections.onTree
+        , Object.buildFragment "UnassignedEvent" selections.onUnassignedEvent
+        , Object.buildFragment "UnlabeledEvent" selections.onUnlabeledEvent
+        , Object.buildFragment "UnlockedEvent" selections.onUnlockedEvent
+        , Object.buildFragment "UnsubscribedEvent" selections.onUnsubscribedEvent
+        , Object.buildFragment "User" selections.onUser
+        , Object.buildFragment "UserContentEdit" selections.onUserContentEdit
+        ]
+
+
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onAddedToProjectEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onAssignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onBaseRefChangedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onBaseRefForcePushedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onBlob = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onBot = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onClosedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommentDeletedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommitComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommitCommentThread = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onConvertedNoteToIssueEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCrossReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDemilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDeployKey = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDeployedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDeployment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDeploymentStatus = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onExternalIdentity = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onGist = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onGistComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefDeletedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefForcePushedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefRestoredEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLabel = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLanguage = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMarketplaceListing = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMentionedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMergedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMilestone = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMovedColumnsInProjectEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrganization = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrganizationIdentityProvider = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrganizationInvitation = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onProject = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onProjectCard = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onProjectColumn = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onProtectedBranch = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPublicKey = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewThread = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPushAllowance = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReaction = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRef = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRelease = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReleaseAsset = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRemovedFromProjectEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRenamedTitleEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReopenedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRepository = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRepositoryInvitation = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRepositoryTopic = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewDismissalAllowance = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewDismissedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewRequestRemovedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewRequestedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onStatus = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onStatusContext = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onSubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTag = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTeam = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTopic = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTree = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnassignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnsubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUserContentEdit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| ID of the object.

--- a/examples/src/Github/Interface/RepositoryNode.elm
+++ b/examples/src/Github/Interface/RepositoryNode.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.RepositoryNode exposing (commonSelection, onCommitComment, onCommitCommentThread, onIssue, onIssueComment, onPullRequest, onPullRequestReview, onPullRequestReviewComment, repository, selection)
+module Github.Interface.RepositoryNode exposing (Fragments, fragments, maybeFragments, repository, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -19,53 +19,54 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.RepositoryNode
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.RepositoryNode
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onCommitComment : SelectionSet decodesTo Github.Object.CommitComment
+    , onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread
+    , onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.RepositoryNode) -> SelectionSet (a -> constructor) Github.Interface.RepositoryNode
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.RepositoryNode
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "CommitComment" selections.onCommitComment
+        , Object.buildFragment "CommitCommentThread" selections.onCommitCommentThread
+        , Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        ]
 
 
-onCommitComment : SelectionSet decodesTo Github.Object.CommitComment -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onCommitComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitComment" fields decoder
-
-
-onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onCommitCommentThread (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitCommentThread" fields decoder
-
-
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Interface.RepositoryNode
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommitComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommitCommentThread = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| The repository associated with this node.

--- a/examples/src/Github/Interface/UniformResourceLocatable.elm
+++ b/examples/src/Github/Interface/UniformResourceLocatable.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.UniformResourceLocatable exposing (commonSelection, onBot, onCrossReferencedEvent, onIssue, onMergedEvent, onMilestone, onOrganization, onPullRequest, onPullRequestCommit, onRelease, onRepository, onRepositoryTopic, onReviewDismissedEvent, onUser, resourcePath, selection, url)
+module Github.Interface.UniformResourceLocatable exposing (Fragments, fragments, maybeFragments, resourcePath, selection, url)
 
 import Github.InputObject
 import Github.Interface
@@ -19,83 +19,72 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.UniformResourceLocatable
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.UniformResourceLocatable
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onBot : SelectionSet decodesTo Github.Object.Bot
+    , onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent
+    , onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent
+    , onMilestone : SelectionSet decodesTo Github.Object.Milestone
+    , onOrganization : SelectionSet decodesTo Github.Object.Organization
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    , onPullRequestCommit : SelectionSet decodesTo Github.Object.PullRequestCommit
+    , onRelease : SelectionSet decodesTo Github.Object.Release
+    , onRepository : SelectionSet decodesTo Github.Object.Repository
+    , onRepositoryTopic : SelectionSet decodesTo Github.Object.RepositoryTopic
+    , onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent
+    , onUser : SelectionSet decodesTo Github.Object.User
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.UniformResourceLocatable) -> SelectionSet (a -> constructor) Github.Interface.UniformResourceLocatable
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.UniformResourceLocatable
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Bot" selections.onBot
+        , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
+        , Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "MergedEvent" selections.onMergedEvent
+        , Object.buildFragment "Milestone" selections.onMilestone
+        , Object.buildFragment "Organization" selections.onOrganization
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        , Object.buildFragment "PullRequestCommit" selections.onPullRequestCommit
+        , Object.buildFragment "Release" selections.onRelease
+        , Object.buildFragment "Repository" selections.onRepository
+        , Object.buildFragment "RepositoryTopic" selections.onRepositoryTopic
+        , Object.buildFragment "ReviewDismissedEvent" selections.onReviewDismissedEvent
+        , Object.buildFragment "User" selections.onUser
+        ]
 
 
-onBot : SelectionSet decodesTo Github.Object.Bot -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onBot (SelectionSet fields decoder) =
-    FragmentSelectionSet "Bot" fields decoder
-
-
-onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onCrossReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "CrossReferencedEvent" fields decoder
-
-
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onMergedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MergedEvent" fields decoder
-
-
-onMilestone : SelectionSet decodesTo Github.Object.Milestone -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onMilestone (SelectionSet fields decoder) =
-    FragmentSelectionSet "Milestone" fields decoder
-
-
-onOrganization : SelectionSet decodesTo Github.Object.Organization -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onOrganization (SelectionSet fields decoder) =
-    FragmentSelectionSet "Organization" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
-
-
-onPullRequestCommit : SelectionSet decodesTo Github.Object.PullRequestCommit -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onPullRequestCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestCommit" fields decoder
-
-
-onRelease : SelectionSet decodesTo Github.Object.Release -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onRelease (SelectionSet fields decoder) =
-    FragmentSelectionSet "Release" fields decoder
-
-
-onRepository : SelectionSet decodesTo Github.Object.Repository -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onRepository (SelectionSet fields decoder) =
-    FragmentSelectionSet "Repository" fields decoder
-
-
-onRepositoryTopic : SelectionSet decodesTo Github.Object.RepositoryTopic -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onRepositoryTopic (SelectionSet fields decoder) =
-    FragmentSelectionSet "RepositoryTopic" fields decoder
-
-
-onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onReviewDismissedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewDismissedEvent" fields decoder
-
-
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Interface.UniformResourceLocatable
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onBot = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCrossReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMergedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMilestone = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrganization = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRelease = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRepository = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRepositoryTopic = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewDismissedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| The HTML path to this resource.

--- a/examples/src/Github/Interface/Updatable.elm
+++ b/examples/src/Github/Interface/Updatable.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.Updatable exposing (commonSelection, onCommitComment, onGistComment, onIssue, onIssueComment, onProject, onPullRequest, onPullRequestReview, onPullRequestReviewComment, selection, viewerCanUpdate)
+module Github.Interface.Updatable exposing (Fragments, fragments, maybeFragments, selection, viewerCanUpdate)
 
 import Github.InputObject
 import Github.Interface
@@ -19,58 +19,57 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Updatable
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.Updatable
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onCommitComment : SelectionSet decodesTo Github.Object.CommitComment
+    , onGistComment : SelectionSet decodesTo Github.Object.GistComment
+    , onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onProject : SelectionSet decodesTo Github.Object.Project
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.Updatable) -> SelectionSet (a -> constructor) Github.Interface.Updatable
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.Updatable
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "CommitComment" selections.onCommitComment
+        , Object.buildFragment "GistComment" selections.onGistComment
+        , Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "Project" selections.onProject
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        ]
 
 
-onCommitComment : SelectionSet decodesTo Github.Object.CommitComment -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onCommitComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitComment" fields decoder
-
-
-onGistComment : SelectionSet decodesTo Github.Object.GistComment -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onGistComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "GistComment" fields decoder
-
-
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onProject : SelectionSet decodesTo Github.Object.Project -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onProject (SelectionSet fields decoder) =
-    FragmentSelectionSet "Project" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Interface.Updatable
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommitComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onGistComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onProject = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| Check if the current viewer can update this object.

--- a/examples/src/Github/Interface/UpdatableComment.elm
+++ b/examples/src/Github/Interface/UpdatableComment.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Interface.UpdatableComment exposing (commonSelection, onCommitComment, onGistComment, onIssue, onIssueComment, onPullRequest, onPullRequestReview, onPullRequestReviewComment, selection, viewerCannotUpdateReasons)
+module Github.Interface.UpdatableComment exposing (Fragments, fragments, maybeFragments, selection, viewerCannotUpdateReasons)
 
 import Github.Enum.CommentCannotUpdateReason
 import Github.InputObject
@@ -20,53 +20,54 @@ import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..)
 import Json.Decode as Decode
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.UpdatableComment
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Github.Interface.UpdatableComment
+selection constructor =
     Object.selection constructor
 
 
-{-| Select both common and type-specific fields from the interface.
+type alias Fragments decodesTo =
+    { onCommitComment : SelectionSet decodesTo Github.Object.CommitComment
+    , onGistComment : SelectionSet decodesTo Github.Object.GistComment
+    , onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Interface.UpdatableComment) -> SelectionSet (a -> constructor) Github.Interface.UpdatableComment
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
+fragments :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Interface.UpdatableComment
+fragments selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "CommitComment" selections.onCommitComment
+        , Object.buildFragment "GistComment" selections.onGistComment
+        , Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        ]
 
 
-onCommitComment : SelectionSet decodesTo Github.Object.CommitComment -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onCommitComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitComment" fields decoder
-
-
-onGistComment : SelectionSet decodesTo Github.Object.GistComment -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onGistComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "GistComment" fields decoder
-
-
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Interface.UpdatableComment
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommitComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onGistComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| Reasons why the current viewer can not update this comment.

--- a/examples/src/Github/Union/Closer.elm
+++ b/examples/src/Github/Union/Closer.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.Closer exposing (onCommit, onPullRequest, selection)
+module Github.Union.Closer exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.Closer) -> SelectionSet constructor Github.Union.Closer
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onCommit : SelectionSet decodesTo Github.Object.Commit
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onCommit : SelectionSet decodesTo Github.Object.Commit -> FragmentSelectionSet decodesTo Github.Union.Closer
-onCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "Commit" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.Closer
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Commit" selections.onCommit
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.Closer
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/CollectionItemContent.elm
+++ b/examples/src/Github/Union/CollectionItemContent.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.CollectionItemContent exposing (onOrganization, onRepository, onUser, selection)
+module Github.Union.CollectionItemContent exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,26 +13,38 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.CollectionItemContent) -> SelectionSet constructor Github.Union.CollectionItemContent
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onRepository : SelectionSet decodesTo Github.Object.Repository
+    , onOrganization : SelectionSet decodesTo Github.Object.Organization
+    , onUser : SelectionSet decodesTo Github.Object.User
+    }
 
 
-onRepository : SelectionSet decodesTo Github.Object.Repository -> FragmentSelectionSet decodesTo Github.Union.CollectionItemContent
-onRepository (SelectionSet fields decoder) =
-    FragmentSelectionSet "Repository" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.CollectionItemContent
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Repository" selections.onRepository
+        , Object.buildFragment "Organization" selections.onOrganization
+        , Object.buildFragment "User" selections.onUser
+        ]
 
 
-onOrganization : SelectionSet decodesTo Github.Object.Organization -> FragmentSelectionSet decodesTo Github.Union.CollectionItemContent
-onOrganization (SelectionSet fields decoder) =
-    FragmentSelectionSet "Organization" fields decoder
-
-
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Union.CollectionItemContent
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onRepository = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrganization = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/IssueOrPullRequest.elm
+++ b/examples/src/Github/Union/IssueOrPullRequest.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.IssueOrPullRequest exposing (onIssue, onPullRequest, selection)
+module Github.Union.IssueOrPullRequest exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.IssueOrPullRequest) -> SelectionSet constructor Github.Union.IssueOrPullRequest
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Union.IssueOrPullRequest
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.IssueOrPullRequest
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.IssueOrPullRequest
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/IssueTimelineItem.elm
+++ b/examples/src/Github/Union/IssueTimelineItem.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.IssueTimelineItem exposing (onAssignedEvent, onClosedEvent, onCommit, onCrossReferencedEvent, onDemilestonedEvent, onIssueComment, onLabeledEvent, onLockedEvent, onMilestonedEvent, onReferencedEvent, onRenamedTitleEvent, onReopenedEvent, onSubscribedEvent, onUnassignedEvent, onUnlabeledEvent, onUnlockedEvent, onUnsubscribedEvent, selection)
+module Github.Union.IssueTimelineItem exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,96 +13,80 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.IssueTimelineItem) -> SelectionSet constructor Github.Union.IssueTimelineItem
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onCommit : SelectionSet decodesTo Github.Object.Commit
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent
+    , onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent
+    , onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent
+    , onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent
+    , onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent
+    , onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent
+    , onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent
+    , onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent
+    , onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent
+    , onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent
+    , onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent
+    , onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent
+    , onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent
+    , onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent
+    , onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent
+    }
 
 
-onCommit : SelectionSet decodesTo Github.Object.Commit -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "Commit" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.IssueTimelineItem
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Commit" selections.onCommit
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
+        , Object.buildFragment "ClosedEvent" selections.onClosedEvent
+        , Object.buildFragment "ReopenedEvent" selections.onReopenedEvent
+        , Object.buildFragment "SubscribedEvent" selections.onSubscribedEvent
+        , Object.buildFragment "UnsubscribedEvent" selections.onUnsubscribedEvent
+        , Object.buildFragment "ReferencedEvent" selections.onReferencedEvent
+        , Object.buildFragment "AssignedEvent" selections.onAssignedEvent
+        , Object.buildFragment "UnassignedEvent" selections.onUnassignedEvent
+        , Object.buildFragment "LabeledEvent" selections.onLabeledEvent
+        , Object.buildFragment "UnlabeledEvent" selections.onUnlabeledEvent
+        , Object.buildFragment "MilestonedEvent" selections.onMilestonedEvent
+        , Object.buildFragment "DemilestonedEvent" selections.onDemilestonedEvent
+        , Object.buildFragment "RenamedTitleEvent" selections.onRenamedTitleEvent
+        , Object.buildFragment "LockedEvent" selections.onLockedEvent
+        , Object.buildFragment "UnlockedEvent" selections.onUnlockedEvent
+        ]
 
 
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onCrossReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "CrossReferencedEvent" fields decoder
-
-
-onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onClosedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ClosedEvent" fields decoder
-
-
-onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onReopenedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReopenedEvent" fields decoder
-
-
-onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onSubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "SubscribedEvent" fields decoder
-
-
-onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onUnsubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnsubscribedEvent" fields decoder
-
-
-onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReferencedEvent" fields decoder
-
-
-onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onAssignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "AssignedEvent" fields decoder
-
-
-onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onUnassignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnassignedEvent" fields decoder
-
-
-onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onLabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LabeledEvent" fields decoder
-
-
-onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onUnlabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlabeledEvent" fields decoder
-
-
-onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onMilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MilestonedEvent" fields decoder
-
-
-onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onDemilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "DemilestonedEvent" fields decoder
-
-
-onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onRenamedTitleEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "RenamedTitleEvent" fields decoder
-
-
-onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onLockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LockedEvent" fields decoder
-
-
-onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent -> FragmentSelectionSet decodesTo Github.Union.IssueTimelineItem
-onUnlockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlockedEvent" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCrossReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onClosedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReopenedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onSubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnsubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onAssignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnassignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDemilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRenamedTitleEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/MilestoneItem.elm
+++ b/examples/src/Github/Union/MilestoneItem.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.MilestoneItem exposing (onIssue, onPullRequest, selection)
+module Github.Union.MilestoneItem exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.MilestoneItem) -> SelectionSet constructor Github.Union.MilestoneItem
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Union.MilestoneItem
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.MilestoneItem
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.MilestoneItem
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/ProjectCardItem.elm
+++ b/examples/src/Github/Union/ProjectCardItem.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.ProjectCardItem exposing (onIssue, onPullRequest, selection)
+module Github.Union.ProjectCardItem exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.ProjectCardItem) -> SelectionSet constructor Github.Union.ProjectCardItem
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Union.ProjectCardItem
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.ProjectCardItem
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.ProjectCardItem
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/PullRequestTimelineItem.elm
+++ b/examples/src/Github/Union/PullRequestTimelineItem.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.PullRequestTimelineItem exposing (onAssignedEvent, onBaseRefForcePushedEvent, onClosedEvent, onCommit, onCommitCommentThread, onCrossReferencedEvent, onDemilestonedEvent, onDeployedEvent, onHeadRefDeletedEvent, onHeadRefForcePushedEvent, onHeadRefRestoredEvent, onIssueComment, onLabeledEvent, onLockedEvent, onMergedEvent, onMilestonedEvent, onPullRequestReview, onPullRequestReviewComment, onPullRequestReviewThread, onReferencedEvent, onRenamedTitleEvent, onReopenedEvent, onReviewDismissedEvent, onReviewRequestRemovedEvent, onReviewRequestedEvent, onSubscribedEvent, onUnassignedEvent, onUnlabeledEvent, onUnlockedEvent, onUnsubscribedEvent, selection)
+module Github.Union.PullRequestTimelineItem exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,161 +13,119 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.PullRequestTimelineItem) -> SelectionSet constructor Github.Union.PullRequestTimelineItem
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onCommit : SelectionSet decodesTo Github.Object.Commit
+    , onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread
+    , onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview
+    , onPullRequestReviewThread : SelectionSet decodesTo Github.Object.PullRequestReviewThread
+    , onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment
+    , onIssueComment : SelectionSet decodesTo Github.Object.IssueComment
+    , onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent
+    , onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent
+    , onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent
+    , onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent
+    , onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent
+    , onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent
+    , onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent
+    , onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent
+    , onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent
+    , onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent
+    , onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent
+    , onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent
+    , onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent
+    , onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent
+    , onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent
+    , onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent
+    , onDeployedEvent : SelectionSet decodesTo Github.Object.DeployedEvent
+    , onHeadRefDeletedEvent : SelectionSet decodesTo Github.Object.HeadRefDeletedEvent
+    , onHeadRefRestoredEvent : SelectionSet decodesTo Github.Object.HeadRefRestoredEvent
+    , onHeadRefForcePushedEvent : SelectionSet decodesTo Github.Object.HeadRefForcePushedEvent
+    , onBaseRefForcePushedEvent : SelectionSet decodesTo Github.Object.BaseRefForcePushedEvent
+    , onReviewRequestedEvent : SelectionSet decodesTo Github.Object.ReviewRequestedEvent
+    , onReviewRequestRemovedEvent : SelectionSet decodesTo Github.Object.ReviewRequestRemovedEvent
+    , onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent
+    }
 
 
-onCommit : SelectionSet decodesTo Github.Object.Commit -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onCommit (SelectionSet fields decoder) =
-    FragmentSelectionSet "Commit" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.PullRequestTimelineItem
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Commit" selections.onCommit
+        , Object.buildFragment "CommitCommentThread" selections.onCommitCommentThread
+        , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
+        , Object.buildFragment "PullRequestReviewThread" selections.onPullRequestReviewThread
+        , Object.buildFragment "PullRequestReviewComment" selections.onPullRequestReviewComment
+        , Object.buildFragment "IssueComment" selections.onIssueComment
+        , Object.buildFragment "ClosedEvent" selections.onClosedEvent
+        , Object.buildFragment "ReopenedEvent" selections.onReopenedEvent
+        , Object.buildFragment "SubscribedEvent" selections.onSubscribedEvent
+        , Object.buildFragment "UnsubscribedEvent" selections.onUnsubscribedEvent
+        , Object.buildFragment "MergedEvent" selections.onMergedEvent
+        , Object.buildFragment "ReferencedEvent" selections.onReferencedEvent
+        , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
+        , Object.buildFragment "AssignedEvent" selections.onAssignedEvent
+        , Object.buildFragment "UnassignedEvent" selections.onUnassignedEvent
+        , Object.buildFragment "LabeledEvent" selections.onLabeledEvent
+        , Object.buildFragment "UnlabeledEvent" selections.onUnlabeledEvent
+        , Object.buildFragment "MilestonedEvent" selections.onMilestonedEvent
+        , Object.buildFragment "DemilestonedEvent" selections.onDemilestonedEvent
+        , Object.buildFragment "RenamedTitleEvent" selections.onRenamedTitleEvent
+        , Object.buildFragment "LockedEvent" selections.onLockedEvent
+        , Object.buildFragment "UnlockedEvent" selections.onUnlockedEvent
+        , Object.buildFragment "DeployedEvent" selections.onDeployedEvent
+        , Object.buildFragment "HeadRefDeletedEvent" selections.onHeadRefDeletedEvent
+        , Object.buildFragment "HeadRefRestoredEvent" selections.onHeadRefRestoredEvent
+        , Object.buildFragment "HeadRefForcePushedEvent" selections.onHeadRefForcePushedEvent
+        , Object.buildFragment "BaseRefForcePushedEvent" selections.onBaseRefForcePushedEvent
+        , Object.buildFragment "ReviewRequestedEvent" selections.onReviewRequestedEvent
+        , Object.buildFragment "ReviewRequestRemovedEvent" selections.onReviewRequestRemovedEvent
+        , Object.buildFragment "ReviewDismissedEvent" selections.onReviewDismissedEvent
+        ]
 
 
-onCommitCommentThread : SelectionSet decodesTo Github.Object.CommitCommentThread -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onCommitCommentThread (SelectionSet fields decoder) =
-    FragmentSelectionSet "CommitCommentThread" fields decoder
-
-
-onPullRequestReview : SelectionSet decodesTo Github.Object.PullRequestReview -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onPullRequestReview (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReview" fields decoder
-
-
-onPullRequestReviewThread : SelectionSet decodesTo Github.Object.PullRequestReviewThread -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onPullRequestReviewThread (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewThread" fields decoder
-
-
-onPullRequestReviewComment : SelectionSet decodesTo Github.Object.PullRequestReviewComment -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onPullRequestReviewComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequestReviewComment" fields decoder
-
-
-onIssueComment : SelectionSet decodesTo Github.Object.IssueComment -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onIssueComment (SelectionSet fields decoder) =
-    FragmentSelectionSet "IssueComment" fields decoder
-
-
-onClosedEvent : SelectionSet decodesTo Github.Object.ClosedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onClosedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ClosedEvent" fields decoder
-
-
-onReopenedEvent : SelectionSet decodesTo Github.Object.ReopenedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onReopenedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReopenedEvent" fields decoder
-
-
-onSubscribedEvent : SelectionSet decodesTo Github.Object.SubscribedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onSubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "SubscribedEvent" fields decoder
-
-
-onUnsubscribedEvent : SelectionSet decodesTo Github.Object.UnsubscribedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onUnsubscribedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnsubscribedEvent" fields decoder
-
-
-onMergedEvent : SelectionSet decodesTo Github.Object.MergedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onMergedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MergedEvent" fields decoder
-
-
-onReferencedEvent : SelectionSet decodesTo Github.Object.ReferencedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReferencedEvent" fields decoder
-
-
-onCrossReferencedEvent : SelectionSet decodesTo Github.Object.CrossReferencedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onCrossReferencedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "CrossReferencedEvent" fields decoder
-
-
-onAssignedEvent : SelectionSet decodesTo Github.Object.AssignedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onAssignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "AssignedEvent" fields decoder
-
-
-onUnassignedEvent : SelectionSet decodesTo Github.Object.UnassignedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onUnassignedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnassignedEvent" fields decoder
-
-
-onLabeledEvent : SelectionSet decodesTo Github.Object.LabeledEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onLabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LabeledEvent" fields decoder
-
-
-onUnlabeledEvent : SelectionSet decodesTo Github.Object.UnlabeledEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onUnlabeledEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlabeledEvent" fields decoder
-
-
-onMilestonedEvent : SelectionSet decodesTo Github.Object.MilestonedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onMilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "MilestonedEvent" fields decoder
-
-
-onDemilestonedEvent : SelectionSet decodesTo Github.Object.DemilestonedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onDemilestonedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "DemilestonedEvent" fields decoder
-
-
-onRenamedTitleEvent : SelectionSet decodesTo Github.Object.RenamedTitleEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onRenamedTitleEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "RenamedTitleEvent" fields decoder
-
-
-onLockedEvent : SelectionSet decodesTo Github.Object.LockedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onLockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "LockedEvent" fields decoder
-
-
-onUnlockedEvent : SelectionSet decodesTo Github.Object.UnlockedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onUnlockedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "UnlockedEvent" fields decoder
-
-
-onDeployedEvent : SelectionSet decodesTo Github.Object.DeployedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onDeployedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "DeployedEvent" fields decoder
-
-
-onHeadRefDeletedEvent : SelectionSet decodesTo Github.Object.HeadRefDeletedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onHeadRefDeletedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefDeletedEvent" fields decoder
-
-
-onHeadRefRestoredEvent : SelectionSet decodesTo Github.Object.HeadRefRestoredEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onHeadRefRestoredEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefRestoredEvent" fields decoder
-
-
-onHeadRefForcePushedEvent : SelectionSet decodesTo Github.Object.HeadRefForcePushedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onHeadRefForcePushedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "HeadRefForcePushedEvent" fields decoder
-
-
-onBaseRefForcePushedEvent : SelectionSet decodesTo Github.Object.BaseRefForcePushedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onBaseRefForcePushedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "BaseRefForcePushedEvent" fields decoder
-
-
-onReviewRequestedEvent : SelectionSet decodesTo Github.Object.ReviewRequestedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onReviewRequestedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewRequestedEvent" fields decoder
-
-
-onReviewRequestRemovedEvent : SelectionSet decodesTo Github.Object.ReviewRequestRemovedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onReviewRequestRemovedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewRequestRemovedEvent" fields decoder
-
-
-onReviewDismissedEvent : SelectionSet decodesTo Github.Object.ReviewDismissedEvent -> FragmentSelectionSet decodesTo Github.Union.PullRequestTimelineItem
-onReviewDismissedEvent (SelectionSet fields decoder) =
-    FragmentSelectionSet "ReviewDismissedEvent" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onCommit = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCommitCommentThread = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReview = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewThread = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequestReviewComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onIssueComment = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onClosedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReopenedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onSubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnsubscribedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMergedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onCrossReferencedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onAssignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnassignedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlabeledEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onMilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDemilestonedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onRenamedTitleEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onLockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onUnlockedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDeployedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefDeletedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefRestoredEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHeadRefForcePushedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onBaseRefForcePushedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewRequestedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewRequestRemovedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onReviewDismissedEvent = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/PushAllowanceActor.elm
+++ b/examples/src/Github/Union/PushAllowanceActor.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.PushAllowanceActor exposing (onTeam, onUser, selection)
+module Github.Union.PushAllowanceActor exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.PushAllowanceActor) -> SelectionSet constructor Github.Union.PushAllowanceActor
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onUser : SelectionSet decodesTo Github.Object.User
+    , onTeam : SelectionSet decodesTo Github.Object.Team
+    }
 
 
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Union.PushAllowanceActor
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.PushAllowanceActor
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "User" selections.onUser
+        , Object.buildFragment "Team" selections.onTeam
+        ]
 
 
-onTeam : SelectionSet decodesTo Github.Object.Team -> FragmentSelectionSet decodesTo Github.Union.PushAllowanceActor
-onTeam (SelectionSet fields decoder) =
-    FragmentSelectionSet "Team" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTeam = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/ReferencedSubject.elm
+++ b/examples/src/Github/Union/ReferencedSubject.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.ReferencedSubject exposing (onIssue, onPullRequest, selection)
+module Github.Union.ReferencedSubject exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.ReferencedSubject) -> SelectionSet constructor Github.Union.ReferencedSubject
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Union.ReferencedSubject
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.ReferencedSubject
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.ReferencedSubject
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/RenamedTitleSubject.elm
+++ b/examples/src/Github/Union/RenamedTitleSubject.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.RenamedTitleSubject exposing (onIssue, onPullRequest, selection)
+module Github.Union.RenamedTitleSubject exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.RenamedTitleSubject) -> SelectionSet constructor Github.Union.RenamedTitleSubject
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onIssue : SelectionSet decodesTo Github.Object.Issue
+    , onPullRequest : SelectionSet decodesTo Github.Object.PullRequest
+    }
 
 
-onIssue : SelectionSet decodesTo Github.Object.Issue -> FragmentSelectionSet decodesTo Github.Union.RenamedTitleSubject
-onIssue (SelectionSet fields decoder) =
-    FragmentSelectionSet "Issue" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.RenamedTitleSubject
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Issue" selections.onIssue
+        , Object.buildFragment "PullRequest" selections.onPullRequest
+        ]
 
 
-onPullRequest : SelectionSet decodesTo Github.Object.PullRequest -> FragmentSelectionSet decodesTo Github.Union.RenamedTitleSubject
-onPullRequest (SelectionSet fields decoder) =
-    FragmentSelectionSet "PullRequest" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onIssue = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onPullRequest = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/RequestedReviewer.elm
+++ b/examples/src/Github/Union/RequestedReviewer.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.RequestedReviewer exposing (onTeam, onUser, selection)
+module Github.Union.RequestedReviewer exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.RequestedReviewer) -> SelectionSet constructor Github.Union.RequestedReviewer
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onUser : SelectionSet decodesTo Github.Object.User
+    , onTeam : SelectionSet decodesTo Github.Object.Team
+    }
 
 
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Union.RequestedReviewer
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.RequestedReviewer
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "User" selections.onUser
+        , Object.buildFragment "Team" selections.onTeam
+        ]
 
 
-onTeam : SelectionSet decodesTo Github.Object.Team -> FragmentSelectionSet decodesTo Github.Union.RequestedReviewer
-onTeam (SelectionSet fields decoder) =
-    FragmentSelectionSet "Team" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTeam = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Github/Union/ReviewDismissalAllowanceActor.elm
+++ b/examples/src/Github/Union/ReviewDismissalAllowanceActor.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Union.ReviewDismissalAllowanceActor exposing (onTeam, onUser, selection)
+module Github.Union.ReviewDismissalAllowanceActor exposing (Fragments, maybeFragments, selection)
 
 import Github.InputObject
 import Github.Interface
@@ -13,21 +13,35 @@ import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Github.Union.ReviewDismissalAllowanceActor) -> SelectionSet constructor Github.Union.ReviewDismissalAllowanceActor
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onUser : SelectionSet decodesTo Github.Object.User
+    , onTeam : SelectionSet decodesTo Github.Object.Team
+    }
 
 
-onUser : SelectionSet decodesTo Github.Object.User -> FragmentSelectionSet decodesTo Github.Union.ReviewDismissalAllowanceActor
-onUser (SelectionSet fields decoder) =
-    FragmentSelectionSet "User" fields decoder
+{-| Build up a selection for this Union by passing in a Fragments record.
+-}
+selection :
+    Fragments decodesTo
+    -> SelectionSet decodesTo Github.Union.ReviewDismissalAllowanceActor
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "User" selections.onUser
+        , Object.buildFragment "Team" selections.onTeam
+        ]
 
 
-onTeam : SelectionSet decodesTo Github.Object.Team -> FragmentSelectionSet decodesTo Github.Union.ReviewDismissalAllowanceActor
-onTeam (SelectionSet fields decoder) =
-    FragmentSelectionSet "Team" fields decoder
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onUser = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onTeam = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/Starwars.elm
+++ b/examples/src/Starwars.elm
@@ -59,6 +59,21 @@ hero =
         |> hardcoded 123
 
 
+nonExhaustiveFragments =
+    -- you can do partial fragments using syntax like this
+    let
+        -- you can't do record update that begins with a module name at the moment
+        -- there are plans to fix that, though, see the "Record Suggestions" section of
+        -- https://github.com/elm/compiler/issues/1375
+        maybeFragments =
+            Character.maybeFragments
+    in
+    { maybeFragments
+        | onDroid =
+            fieldSelection (Droid.primaryFunction |> Field.map (Droid >> Just))
+    }
+
+
 type alias CharacterUnion =
     { details : Maybe HumanOrDroid
     }

--- a/examples/src/Starwars.elm
+++ b/examples/src/Starwars.elm
@@ -28,7 +28,7 @@ type alias Response =
     { vader : HumanLookup
     , tarkin : HumanLookup
     , hero : Character
-    , union : Maybe CharacterUnion
+    , union : HumanOrDroid
     , greeting : String
     }
 
@@ -75,17 +75,12 @@ nonExhaustiveFragments =
     }
 
 
-type alias CharacterUnion =
-    { details : Maybe HumanOrDroid
-    }
-
-
-heroUnion : SelectionSet CharacterUnion Swapi.Union.CharacterUnion
+heroUnion : SelectionSet HumanOrDroid Swapi.Union.CharacterUnion
 heroUnion =
-    CharacterUnion.selection CharacterUnion
-        [ CharacterUnion.onDroid (Droid.selection Droid |> with Droid.primaryFunction)
-        , CharacterUnion.onHuman (Human.selection Human |> with Human.homePlanet)
-        ]
+    CharacterUnion.selection
+        { onDroid = Droid.selection Droid |> with Droid.primaryFunction
+        , onHuman = Human.selection Human |> with Human.homePlanet
+        }
 
 
 query : SelectionSet Response RootQuery

--- a/examples/src/Starwars.elm
+++ b/examples/src/Starwars.elm
@@ -6,7 +6,7 @@ import Graphql.Field as Field
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, hardcoded, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with)
 import Html exposing (div, h1, p, pre, text)
 import PrintAny
 import RemoteData exposing (RemoteData)
@@ -39,7 +39,7 @@ type HumanOrDroid
 
 
 type alias Character =
-    { details : Maybe HumanOrDroid
+    { details : HumanOrDroid
     , name : String
     , id : Swapi.Scalar.Id
     , friends : List String
@@ -49,13 +49,13 @@ type alias Character =
 
 hero : SelectionSet Character Swapi.Interface.Character
 hero =
-    Character.selection Character
-        [ Character.onDroid (Droid.selection Droid |> with Droid.primaryFunction)
-        , Character.onHuman (Human.selection Human |> with Human.homePlanet)
-        ]
+    Character.completeAndCommonSelection Character
+        { onDroid = Droid.selection Droid |> with Droid.primaryFunction
+        , onHuman = Human.selection Human |> with Human.homePlanet
+        }
         |> with Character.name
         |> with Character.id
-        |> with (Character.friends (Character.commonSelection identity |> with Character.name))
+        |> with (Character.friends (fieldSelection Character.name))
         |> hardcoded 123
 
 

--- a/examples/src/Starwars.elm
+++ b/examples/src/Starwars.elm
@@ -6,7 +6,7 @@ import Graphql.Field as Field
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, fieldSelection, hardcoded, with, withFragment)
 import Html exposing (div, h1, p, pre, text)
 import PrintAny
 import RemoteData exposing (RemoteData)
@@ -43,20 +43,21 @@ type alias Character =
     , name : String
     , id : Swapi.Scalar.Id
     , friends : List String
-    , myNum : Int
     }
 
 
 hero : SelectionSet Character Swapi.Interface.Character
 hero =
-    Character.completeAndCommonSelection Character
-        { onDroid = Droid.selection Droid |> with Droid.primaryFunction
-        , onHuman = Human.selection Human |> with Human.homePlanet
-        }
+    Character.selection Character
+        |> withFragment
+            (Character.fragments
+                { onDroid = Droid.selection Droid |> with Droid.primaryFunction
+                , onHuman = Human.selection Human |> with Human.homePlanet
+                }
+            )
         |> with Character.name
         |> with Character.id
         |> with (Character.friends (fieldSelection Character.name))
-        |> hardcoded 123
 
 
 nonExhaustiveFragments =

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, maybeFragments, name, onDroid, onHuman, selection)
+module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, maybeFragments, name, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -44,8 +44,8 @@ completeSelection :
     -> SelectionSet decodesTo Swapi.Interface.Character
 completeSelection selections =
     Object.exhuastiveFragmentSelection
-        [ onDroid selections.onDroid
-        , onHuman selections.onHuman
+        [ Object.buildFragment "Droid" selections.onDroid
+        , Object.buildFragment "Human" selections.onHuman
         ]
 
 
@@ -73,19 +73,9 @@ completeAndCommonSelection :
     -> SelectionSet (a -> constructor) Swapi.Interface.Character
 completeAndCommonSelection constructor selections =
     Object.exhuastiveAndCommonFragmentSelection constructor
-        [ onDroid selections.onDroid
-        , onHuman selections.onHuman
+        [ Object.buildFragment "Droid" selections.onDroid
+        , Object.buildFragment "Human" selections.onHuman
         ]
-
-
-onHuman : SelectionSet decodesTo Swapi.Object.Human -> FragmentSelectionSet decodesTo Swapi.Interface.Character
-onHuman (SelectionSet fields decoder) =
-    FragmentSelectionSet "Human" fields decoder
-
-
-onDroid : SelectionSet decodesTo Swapi.Object.Droid -> FragmentSelectionSet decodesTo Swapi.Interface.Character
-onDroid (SelectionSet fields decoder) =
-    FragmentSelectionSet "Droid" fields decoder
 
 
 {-| Which movies they appear in.

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Interface.Character exposing (appearsIn, avatarUrl, completeAndCommonSelection, fragments, friends, id, maybeFragments, name, selection)
+module Swapi.Interface.Character exposing (Fragments, appearsIn, avatarUrl, fragments, friends, id, maybeFragments, name, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -20,52 +20,39 @@ import Swapi.Scalar
 import Swapi.Union
 
 
-{-| Select only common fields from the interface.
+{-| Select fields to build up a SelectionSet for this Interface.
 -}
 selection : (a -> constructor) -> SelectionSet (a -> constructor) Swapi.Interface.Character
 selection constructor =
     Object.selection constructor
 
 
-{-| Complete selection
+type alias Fragments decodesTo =
+    { onHuman : SelectionSet decodesTo Swapi.Object.Human
+    , onDroid : SelectionSet decodesTo Swapi.Object.Droid
+    }
+
+
+{-| Build an exhaustive selection of type-specific fragments.
 -}
 fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Interface.Character
 fragments selections =
     Object.exhuastiveFragmentSelection
-        [ Object.buildFragment "Droid" selections.onDroid
-        , Object.buildFragment "Human" selections.onHuman
+        [ Object.buildFragment "Human" selections.onHuman
+        , Object.buildFragment "Droid" selections.onDroid
         ]
 
 
-type alias Fragments decodesTo =
-    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
-    , onHuman : SelectionSet decodesTo Swapi.Object.Human
-    }
-
-
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
 maybeFragments : Fragments (Maybe a)
 maybeFragments =
-    { onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
-    , onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    { onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
     }
-
-
-{-| Complete selection
--}
-completeAndCommonSelection :
-    (decodesTo -> a -> constructor)
-    ->
-        { onDroid : SelectionSet decodesTo Swapi.Object.Droid
-        , onHuman : SelectionSet decodesTo Swapi.Object.Human
-        }
-    -> SelectionSet (a -> constructor) Swapi.Interface.Character
-completeAndCommonSelection constructor selections =
-    Object.exhuastiveAndCommonFragmentSelection constructor
-        [ Object.buildFragment "Droid" selections.onDroid
-        , Object.buildFragment "Human" selections.onHuman
-        ]
 
 
 {-| Which movies they appear in.

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, maybeFragments, name, selection)
+module Swapi.Interface.Character exposing (appearsIn, avatarUrl, completeAndCommonSelection, fragments, friends, id, maybeFragments, name, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -22,27 +22,17 @@ import Swapi.Union
 
 {-| Select only common fields from the interface.
 -}
-commonSelection : (a -> constructor) -> SelectionSet (a -> constructor) Swapi.Interface.Character
-commonSelection constructor =
+selection : (a -> constructor) -> SelectionSet (a -> constructor) Swapi.Interface.Character
+selection constructor =
     Object.selection constructor
-
-
-{-| Select both common and type-specific fields from the interface.
--}
-selection :
-    (Maybe typeSpecific -> a -> constructor)
-    -> List (FragmentSelectionSet typeSpecific Swapi.Interface.Character)
-    -> SelectionSet (a -> constructor) Swapi.Interface.Character
-selection constructor typeSpecificDecoders =
-    Object.interfaceSelection typeSpecificDecoders constructor
 
 
 {-| Complete selection
 -}
-completeSelection :
+fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Interface.Character
-completeSelection selections =
+fragments selections =
     Object.exhuastiveFragmentSelection
         [ Object.buildFragment "Droid" selections.onDroid
         , Object.buildFragment "Human" selections.onHuman

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, friends, id, name, onDroid, onHuman, selection)
+module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, name, onDroid, onHuman, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -29,9 +29,42 @@ commonSelection constructor =
 
 {-| Select both common and type-specific fields from the interface.
 -}
-selection : (Maybe typeSpecific -> a -> constructor) -> List (FragmentSelectionSet typeSpecific Swapi.Interface.Character) -> SelectionSet (a -> constructor) Swapi.Interface.Character
+selection :
+    (Maybe typeSpecific -> a -> constructor)
+    -> List (FragmentSelectionSet typeSpecific Swapi.Interface.Character)
+    -> SelectionSet (a -> constructor) Swapi.Interface.Character
 selection constructor typeSpecificDecoders =
     Object.interfaceSelection typeSpecificDecoders constructor
+
+
+{-| Complete selection
+-}
+completeSelection :
+    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
+    , onHuman : SelectionSet decodesTo Swapi.Object.Human
+    }
+    -> SelectionSet decodesTo Swapi.Interface.Character
+completeSelection selections =
+    Object.exhuastiveFragmentSelection
+        [ onDroid selections.onDroid
+        , onHuman selections.onHuman
+        ]
+
+
+{-| Complete selection
+-}
+completeAndCommonSelection :
+    (decodesTo -> a -> constructor)
+    ->
+        { onDroid : SelectionSet decodesTo Swapi.Object.Droid
+        , onHuman : SelectionSet decodesTo Swapi.Object.Human
+        }
+    -> SelectionSet (a -> constructor) Swapi.Interface.Character
+completeAndCommonSelection constructor selections =
+    Object.exhuastiveAndCommonFragmentSelection constructor
+        [ onDroid selections.onDroid
+        , onHuman selections.onHuman
+        ]
 
 
 onHuman : SelectionSet decodesTo Swapi.Object.Human -> FragmentSelectionSet decodesTo Swapi.Interface.Character

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, name, onDroid, onHuman, selection)
+module Swapi.Interface.Character exposing (appearsIn, avatarUrl, commonSelection, completeAndCommonSelection, friends, id, maybeFragments, name, onDroid, onHuman, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -40,15 +40,26 @@ selection constructor typeSpecificDecoders =
 {-| Complete selection
 -}
 completeSelection :
-    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
-    , onHuman : SelectionSet decodesTo Swapi.Object.Human
-    }
+    Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Interface.Character
 completeSelection selections =
     Object.exhuastiveFragmentSelection
         [ onDroid selections.onDroid
         , onHuman selections.onHuman
         ]
+
+
+type alias Fragments decodesTo =
+    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
+    , onHuman : SelectionSet decodesTo Swapi.Object.Human
+    }
+
+
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
 {-| Complete selection

--- a/examples/src/Swapi/Query.elm
+++ b/examples/src/Swapi/Query.elm
@@ -89,7 +89,7 @@ type alias HeroUnionOptionalArguments =
   - episode - If omitted, returns the hero of the whole saga. If provided, returns the hero of that particular episode.
 
 -}
-heroUnion : (HeroUnionOptionalArguments -> HeroUnionOptionalArguments) -> SelectionSet decodesTo Swapi.Union.CharacterUnion -> Field (Maybe decodesTo) RootQuery
+heroUnion : (HeroUnionOptionalArguments -> HeroUnionOptionalArguments) -> SelectionSet decodesTo Swapi.Union.CharacterUnion -> Field decodesTo RootQuery
 heroUnion fillInOptionals object_ =
     let
         filledInOptionals =
@@ -99,7 +99,7 @@ heroUnion fillInOptionals object_ =
             [ Argument.optional "episode" filledInOptionals.episode (Encode.enum Swapi.Enum.Episode.toString) ]
                 |> List.filterMap identity
     in
-    Object.selectionField "heroUnion" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionField "heroUnion" optionalArgs object_ identity
 
 
 type alias HumanRequiredArguments =

--- a/examples/src/Swapi/Union/CharacterUnion.elm
+++ b/examples/src/Swapi/Union/CharacterUnion.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Union.CharacterUnion exposing (onDroid, onHuman, selection)
+module Swapi.Union.CharacterUnion exposing (selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
@@ -18,16 +18,28 @@ import Swapi.Scalar
 import Swapi.Union
 
 
-selection : (Maybe typeSpecific -> constructor) -> List (FragmentSelectionSet typeSpecific Swapi.Union.CharacterUnion) -> SelectionSet constructor Swapi.Union.CharacterUnion
-selection constructor typeSpecificDecoders =
-    Object.unionSelection typeSpecificDecoders constructor
+type alias Fragments decodesTo =
+    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
+    , onHuman : SelectionSet decodesTo Swapi.Object.Human
+    }
 
 
-onHuman : SelectionSet decodesTo Swapi.Object.Human -> FragmentSelectionSet decodesTo Swapi.Union.CharacterUnion
-onHuman (SelectionSet fields decoder) =
-    FragmentSelectionSet "Human" fields decoder
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }
 
 
-onDroid : SelectionSet decodesTo Swapi.Object.Droid -> FragmentSelectionSet decodesTo Swapi.Union.CharacterUnion
-onDroid (SelectionSet fields decoder) =
-    FragmentSelectionSet "Droid" fields decoder
+{-| Complete selection
+-}
+selection :
+    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
+    , onHuman : SelectionSet decodesTo Swapi.Object.Human
+    }
+    -> SelectionSet decodesTo Swapi.Union.CharacterUnion
+selection selections =
+    Object.exhuastiveFragmentSelection
+        [ Object.buildFragment "Droid" selections.onDroid
+        , Object.buildFragment "Human" selections.onHuman
+        ]

--- a/examples/src/Swapi/Union/CharacterUnion.elm
+++ b/examples/src/Swapi/Union/CharacterUnion.elm
@@ -2,12 +2,13 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Swapi.Union.CharacterUnion exposing (selection)
+module Swapi.Union.CharacterUnion exposing (Fragments, maybeFragments, selection)
 
 import Graphql.Field as Field exposing (Field)
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode
@@ -19,27 +20,28 @@ import Swapi.Union
 
 
 type alias Fragments decodesTo =
-    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
-    , onHuman : SelectionSet decodesTo Swapi.Object.Human
+    { onHuman : SelectionSet decodesTo Swapi.Object.Human
+    , onDroid : SelectionSet decodesTo Swapi.Object.Droid
     }
 
 
-maybeFragments : Fragments (Maybe a)
-maybeFragments =
-    { onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
-    , onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
-    }
-
-
-{-| Complete selection
+{-| Build up a selection for this Union by passing in a Fragments record.
 -}
 selection :
-    { onDroid : SelectionSet decodesTo Swapi.Object.Droid
-    , onHuman : SelectionSet decodesTo Swapi.Object.Human
-    }
+    Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Union.CharacterUnion
 selection selections =
     Object.exhuastiveFragmentSelection
-        [ Object.buildFragment "Droid" selections.onDroid
-        , Object.buildFragment "Human" selections.onHuman
+        [ Object.buildFragment "Human" selections.onHuman
+        , Object.buildFragment "Droid" selections.onDroid
         ]
+
+
+{-| Can be used to create a non-exhuastive set of fragments by using the record
+update syntax to add `SelectionSet`s for the types you want to handle.
+-}
+maybeFragments : Fragments (Maybe a)
+maybeFragments =
+    { onHuman = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onDroid = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    }

--- a/examples/src/complex/ElmReposRequest.elm
+++ b/examples/src/complex/ElmReposRequest.elm
@@ -98,9 +98,16 @@ withDefault default =
 
 searchResultSelection : SelectionSet (Maybe Repo) Github.Union.SearchResultItem
 searchResultSelection =
-    Github.Union.SearchResultItem.selection identity
-        [ Github.Union.SearchResultItem.onRepository repositorySelection
-        ]
+    let
+        maybeFragments =
+            Github.Union.SearchResultItem.maybeFragments
+
+        partialFragments =
+            { maybeFragments
+                | onRepository = repositorySelection |> SelectionSet.map Just
+            }
+    in
+    Github.Union.SearchResultItem.selection partialFragments
 
 
 repositorySelection : SelectionSet Repo Github.Object.Repository
@@ -160,6 +167,6 @@ type alias Owner =
 
 ownerSelection : SelectionSet Owner Github.Interface.RepositoryOwner
 ownerSelection =
-    Github.Interface.RepositoryOwner.commonSelection Owner
+    Github.Interface.RepositoryOwner.selection Owner
         |> with (Github.Interface.RepositoryOwner.avatarUrl identity)
         |> with Github.Interface.RepositoryOwner.login

--- a/examples/src/subscription/Main.elm
+++ b/examples/src/subscription/Main.elm
@@ -52,7 +52,7 @@ type alias Character =
 
 characterSelection : SelectionSet Character Swapi.Interface.Character
 characterSelection =
-    Swapi.Interface.Character.commonSelection Character
+    Swapi.Interface.Character.selection Character
         |> with Swapi.Interface.Character.name
         |> with Swapi.Interface.Character.avatarUrl
 

--- a/src/Graphql/Internal/Builder/Object.elm
+++ b/src/Graphql/Internal/Builder/Object.elm
@@ -1,14 +1,11 @@
-module Graphql.Internal.Builder.Object exposing
-    ( fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection
-    , buildFragment
-    )
+module Graphql.Internal.Builder.Object exposing (fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection, buildFragment)
 
 {-| **WARNING** `Graphql.Interal` modules are used by the `@dillonkearns/elm-graphql` command line
 code generator tool. They should not be consumed through hand-written code.
 
 Internal functions for use by auto-generated code from the `@dillonkearns/elm-graphql` CLI.
 
-@docs fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection
+@docs fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection, buildFragment
 
 -}
 
@@ -78,6 +75,8 @@ selection constructor =
     SelectionSet [] (Decode.succeed constructor)
 
 
+{-| Used to create FragmentSelectionSets for type-specific fragmentsin auto-generated code.
+-}
 buildFragment : String -> SelectionSet decodesTo selectionLock -> FragmentSelectionSet decodesTo fragmentLock
 buildFragment fragmentTypeName (SelectionSet fields decoder) =
     FragmentSelectionSet fragmentTypeName fields decoder

--- a/src/Graphql/Internal/Builder/Object.elm
+++ b/src/Graphql/Internal/Builder/Object.elm
@@ -1,4 +1,7 @@
-module Graphql.Internal.Builder.Object exposing (fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection)
+module Graphql.Internal.Builder.Object exposing
+    ( fieldDecoder, selection, selectionField, interfaceSelection, unionSelection, scalarDecoder, exhuastiveFragmentSelection, exhuastiveAndCommonFragmentSelection
+    , buildFragment
+    )
 
 {-| **WARNING** `Graphql.Interal` modules are used by the `@dillonkearns/elm-graphql` command line
 code generator tool. They should not be consumed through hand-written code.
@@ -73,6 +76,11 @@ leaf fieldName args =
 selection : (a -> constructor) -> SelectionSet (a -> constructor) typeLock
 selection constructor =
     SelectionSet [] (Decode.succeed constructor)
+
+
+buildFragment : String -> SelectionSet decodesTo selectionLock -> FragmentSelectionSet decodesTo fragmentLock
+buildFragment fragmentTypeName (SelectionSet fields decoder) =
+    FragmentSelectionSet fragmentTypeName fields decoder
 
 
 {-| Used to create the `selection` functions in auto-generated code for interfaces.


### PR DESCRIPTION
This change allows you to do exhaustive type-specific fragments. Now, if you add a new type to a Union or Interface in your schema, the Elm compiler will tell you to check for that type if you're doing an exhaustive selection. See this diff to understand the changes and how to migrate to the new version: https://github.com/dillonkearns/elm-graphql/pull/85/commits/e530d94cded94f43135aa7e68233ab4f8b7e5912.