### PR TITLE
Replace RawGit with jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://cdn.rawgit.com/martimatix/logo-graphqelm/master/logo.svg" alt="dillonearns/elm-graphql logo" width="40%" align="right">
+<img src="https://cdn.jsdelivr.net/gh/martimatix/logo-graphqelm/logo.svg" alt="dillonearns/elm-graphql logo" width="40%" align="right">
 
 # dillonkearns/elm-graphql
 


### PR DESCRIPTION
[RawGit](https://rawgit.com/) is shutting down. This PR replaces the RawGit link with the recommended alternative - [jsDelivr](https://www.jsdelivr.com/). jsDelivr is a free and fast open source CDN hosting all files from GitHub and npm.

I have tested this at https://github.com/martimatix/logo-graphqelm and confirm that it renders correctly in a Github readme.