### PR TITLE
Fix typo 

### DIFF
--- a/ete_tests/src/Normalize/Interface/Character.elm
+++ b/ete_tests/src/Normalize/Interface/Character.elm
@@ -31,13 +31,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Normalize.Interface.Character
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "_human" selections.onHuman_
         , Object.buildFragment "Droid" selections.onDroid
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/ete_tests/src/Normalize/Union/CharacterUnion.elm
+++ b/ete_tests/src/Normalize/Union/CharacterUnion.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Normalize.Union.CharacterUnion
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "_human" selections.onHuman_
         , Object.buildFragment "Droid" selections.onDroid
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/ete_tests/src/Normalize/Union/ConflictingTypesUnion.elm
+++ b/ete_tests/src/Normalize/Union/ConflictingTypesUnion.elm
@@ -32,7 +32,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Normalize.Union.ConflictingTypesUnion
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Dog" selections.onDog
         , Object.buildFragment "Cat" selections.onCat
         , Object.buildFragment "MaybeId" selections.onMaybeId
@@ -40,7 +40,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Actor.elm
+++ b/examples/src/Github/Interface/Actor.elm
@@ -31,14 +31,14 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Actor
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Bot" selections.onBot
         , Object.buildFragment "Organization" selections.onOrganization
         , Object.buildFragment "User" selections.onUser
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Assignable.elm
+++ b/examples/src/Github/Interface/Assignable.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Assignable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Closable.elm
+++ b/examples/src/Github/Interface/Closable.elm
@@ -32,7 +32,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Closable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "Milestone" selections.onMilestone
         , Object.buildFragment "Project" selections.onProject
@@ -40,7 +40,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Comment.elm
+++ b/examples/src/Github/Interface/Comment.elm
@@ -36,7 +36,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Comment
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "GistComment" selections.onGistComment
         , Object.buildFragment "Issue" selections.onIssue
@@ -47,7 +47,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Deletable.elm
+++ b/examples/src/Github/Interface/Deletable.elm
@@ -33,7 +33,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Deletable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "GistComment" selections.onGistComment
         , Object.buildFragment "IssueComment" selections.onIssueComment
@@ -42,7 +42,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/GitObject.elm
+++ b/examples/src/Github/Interface/GitObject.elm
@@ -32,7 +32,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.GitObject
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Blob" selections.onBlob
         , Object.buildFragment "Commit" selections.onCommit
         , Object.buildFragment "Tag" selections.onTag
@@ -40,7 +40,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/GitSignature.elm
+++ b/examples/src/Github/Interface/GitSignature.elm
@@ -32,14 +32,14 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.GitSignature
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "GpgSignature" selections.onGpgSignature
         , Object.buildFragment "SmimeSignature" selections.onSmimeSignature
         , Object.buildFragment "UnknownSignature" selections.onUnknownSignature
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Labelable.elm
+++ b/examples/src/Github/Interface/Labelable.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Labelable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Lockable.elm
+++ b/examples/src/Github/Interface/Lockable.elm
@@ -31,13 +31,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Lockable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Node.elm
+++ b/examples/src/Github/Interface/Node.elm
@@ -107,7 +107,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Node
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "AddedToProjectEvent" selections.onAddedToProjectEvent
         , Object.buildFragment "AssignedEvent" selections.onAssignedEvent
         , Object.buildFragment "BaseRefChangedEvent" selections.onBaseRefChangedEvent
@@ -190,7 +190,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/ProjectOwner.elm
+++ b/examples/src/Github/Interface/ProjectOwner.elm
@@ -31,13 +31,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.ProjectOwner
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Organization" selections.onOrganization
         , Object.buildFragment "Repository" selections.onRepository
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Reactable.elm
+++ b/examples/src/Github/Interface/Reactable.elm
@@ -34,7 +34,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Reactable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "IssueComment" selections.onIssueComment
@@ -43,7 +43,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/RepositoryInfo.elm
+++ b/examples/src/Github/Interface/RepositoryInfo.elm
@@ -31,13 +31,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.RepositoryInfo
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Repository" selections.onRepository
         , Object.buildFragment "RepositoryInvitationRepository" selections.onRepositoryInvitationRepository
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/RepositoryNode.elm
+++ b/examples/src/Github/Interface/RepositoryNode.elm
@@ -35,7 +35,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.RepositoryNode
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "CommitCommentThread" selections.onCommitCommentThread
         , Object.buildFragment "Issue" selections.onIssue
@@ -46,7 +46,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/RepositoryOwner.elm
+++ b/examples/src/Github/Interface/RepositoryOwner.elm
@@ -32,13 +32,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.RepositoryOwner
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Organization" selections.onOrganization
         , Object.buildFragment "User" selections.onUser
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Starrable.elm
+++ b/examples/src/Github/Interface/Starrable.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Starrable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Gist" selections.onGist
         , Object.buildFragment "Repository" selections.onRepository
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Subscribable.elm
+++ b/examples/src/Github/Interface/Subscribable.elm
@@ -34,7 +34,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Subscribable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Commit" selections.onCommit
         , Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
@@ -43,7 +43,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/UniformResourceLocatable.elm
+++ b/examples/src/Github/Interface/UniformResourceLocatable.elm
@@ -41,7 +41,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.UniformResourceLocatable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Bot" selections.onBot
         , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
         , Object.buildFragment "Issue" selections.onIssue
@@ -58,7 +58,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/Updatable.elm
+++ b/examples/src/Github/Interface/Updatable.elm
@@ -36,7 +36,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.Updatable
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "GistComment" selections.onGistComment
         , Object.buildFragment "Issue" selections.onIssue
@@ -48,7 +48,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Interface/UpdatableComment.elm
+++ b/examples/src/Github/Interface/UpdatableComment.elm
@@ -36,7 +36,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Interface.UpdatableComment
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "CommitComment" selections.onCommitComment
         , Object.buildFragment "GistComment" selections.onGistComment
         , Object.buildFragment "Issue" selections.onIssue
@@ -47,7 +47,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/Closer.elm
+++ b/examples/src/Github/Union/Closer.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.Closer
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Commit" selections.onCommit
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/CollectionItemContent.elm
+++ b/examples/src/Github/Union/CollectionItemContent.elm
@@ -31,14 +31,14 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.CollectionItemContent
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Repository" selections.onRepository
         , Object.buildFragment "Organization" selections.onOrganization
         , Object.buildFragment "User" selections.onUser
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/IssueOrPullRequest.elm
+++ b/examples/src/Github/Union/IssueOrPullRequest.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.IssueOrPullRequest
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/IssueTimelineItem.elm
+++ b/examples/src/Github/Union/IssueTimelineItem.elm
@@ -45,7 +45,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.IssueTimelineItem
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Commit" selections.onCommit
         , Object.buildFragment "IssueComment" selections.onIssueComment
         , Object.buildFragment "CrossReferencedEvent" selections.onCrossReferencedEvent
@@ -66,7 +66,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/MilestoneItem.elm
+++ b/examples/src/Github/Union/MilestoneItem.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.MilestoneItem
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/ProjectCardItem.elm
+++ b/examples/src/Github/Union/ProjectCardItem.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.ProjectCardItem
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/PullRequestTimelineItem.elm
+++ b/examples/src/Github/Union/PullRequestTimelineItem.elm
@@ -58,7 +58,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.PullRequestTimelineItem
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Commit" selections.onCommit
         , Object.buildFragment "CommitCommentThread" selections.onCommitCommentThread
         , Object.buildFragment "PullRequestReview" selections.onPullRequestReview
@@ -92,7 +92,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/PushAllowanceActor.elm
+++ b/examples/src/Github/Union/PushAllowanceActor.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.PushAllowanceActor
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "User" selections.onUser
         , Object.buildFragment "Team" selections.onTeam
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/ReferencedSubject.elm
+++ b/examples/src/Github/Union/ReferencedSubject.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.ReferencedSubject
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/RenamedTitleSubject.elm
+++ b/examples/src/Github/Union/RenamedTitleSubject.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.RenamedTitleSubject
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/RequestedReviewer.elm
+++ b/examples/src/Github/Union/RequestedReviewer.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.RequestedReviewer
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "User" selections.onUser
         , Object.buildFragment "Team" selections.onTeam
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/ReviewDismissalAllowanceActor.elm
+++ b/examples/src/Github/Union/ReviewDismissalAllowanceActor.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.ReviewDismissalAllowanceActor
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "User" selections.onUser
         , Object.buildFragment "Team" selections.onTeam
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Github/Union/SearchResultItem.elm
+++ b/examples/src/Github/Union/SearchResultItem.elm
@@ -34,7 +34,7 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Github.Union.SearchResultItem
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Issue" selections.onIssue
         , Object.buildFragment "PullRequest" selections.onPullRequest
         , Object.buildFragment "Repository" selections.onRepository
@@ -44,7 +44,7 @@ fragments selections =
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Swapi/Interface/Character.elm
+++ b/examples/src/Swapi/Interface/Character.elm
@@ -31,13 +31,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Interface.Character
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Human" selections.onHuman
         , Object.buildFragment "Droid" selections.onDroid
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/examples/src/Swapi/Union/CharacterUnion.elm
+++ b/examples/src/Swapi/Union/CharacterUnion.elm
@@ -30,13 +30,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Swapi.Union.CharacterUnion
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Human" selections.onHuman
         , Object.buildFragment "Droid" selections.onDroid
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/generator/src/Graphql/Generator/Interface.elm
+++ b/generator/src/Graphql/Generator/Interface.elm
@@ -33,13 +33,13 @@ fragments :
       Fragments decodesTo
       -> SelectionSet decodesTo {0}
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [
          {2}
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/generator/src/Graphql/Generator/Union.elm
+++ b/generator/src/Graphql/Generator/Union.elm
@@ -28,13 +28,13 @@ fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo {0}
 fragments selections =
-    Object.exhuastiveFragmentSelection
+    Object.exhaustiveFragmentSelection
         [
           {2}
         ]
 
 
-{-| Can be used to create a non-exhuastive set of fragments by using the record
+{-| Can be used to create a non-exhaustive set of fragments by using the record
 update syntax to add `SelectionSet`s for the types you want to handle.
 -}
 maybeFragments : Fragments (Maybe decodesTo)

--- a/src/Graphql/Internal/Builder/Object.elm
+++ b/src/Graphql/Internal/Builder/Object.elm
@@ -1,11 +1,11 @@
-module Graphql.Internal.Builder.Object exposing (scalarDecoder, exhuastiveFragmentSelection, buildFragment, selectionForField, selectionForCompositeField)
+module Graphql.Internal.Builder.Object exposing (scalarDecoder, exhaustiveFragmentSelection, buildFragment, selectionForField, selectionForCompositeField)
 
 {-| **WARNING** `Graphql.Interal` modules are used by the `@dillonkearns/elm-graphql` command line
 code generator tool. They should not be consumed through hand-written code.
 
 Internal functions for use by auto-generated code from the `@dillonkearns/elm-graphql` CLI.
 
-@docs scalarDecoder, exhuastiveFragmentSelection, buildFragment, selectionForField, selectionForCompositeField
+@docs scalarDecoder, exhaustiveFragmentSelection, buildFragment, selectionForField, selectionForCompositeField
 
 -}
 
@@ -87,10 +87,10 @@ buildFragment fragmentTypeName (SelectionSet fields decoder) =
     FragmentSelectionSet fragmentTypeName fields decoder
 
 
-{-| Used to create the `selection` functions in auto-generated code for exhuastive fragments.
+{-| Used to create the `selection` functions in auto-generated code for exhaustive fragments.
 -}
-exhuastiveFragmentSelection : List (FragmentSelectionSet decodesTo typeLock) -> SelectionSet decodesTo typeLock
-exhuastiveFragmentSelection typeSpecificSelections =
+exhaustiveFragmentSelection : List (FragmentSelectionSet decodesTo typeLock) -> SelectionSet decodesTo typeLock
+exhaustiveFragmentSelection typeSpecificSelections =
     let
         selections =
             typeSpecificSelections


### PR DESCRIPTION
Hi, Your masterpiece helps me so many times. Thank you very much 😸   

I found that `Graphql.Internal.Builder.Object` has a function named `exhuastiveFragmentSelection` which seems typo.

So, I replaced whole `exhuastive~` to `exhaustive~` 🖖 
