### PR TITLE
Foolproof Relay Pagination API

### DIFF
--- a/examples/src/Github/Object/PageInfo.elm
+++ b/examples/src/Github/Object/PageInfo.elm
@@ -15,12 +15,12 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+import Graphql.PaginatorSetup exposing (CurrentPage, Direction(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-fromSetup : PaginatorSetup -> SelectionSet (CurrentPage String) Github.Object.PageInfo
+fromSetup : Direction -> SelectionSet (CurrentPage String) Github.Object.PageInfo
 fromSetup paginatorSetup =
     Graphql.SelectionSet.map2 CurrentPage
         endCursor

--- a/examples/src/Github/Object/PageInfo.elm
+++ b/examples/src/Github/Object/PageInfo.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Object.PageInfo exposing (endCursor, hasNextPage, hasPreviousPage, startCursor)
+module Github.Object.PageInfo exposing (endCursor, fromSetup, hasNextPage, hasPreviousPage, startCursor)
 
 import Github.InputObject
 import Github.Interface
@@ -15,8 +15,20 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
+import Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
+
+
+fromSetup : PaginatorSetup -> SelectionSet (CurrentPage String) Github.Object.PageInfo
+fromSetup paginatorSetup =
+    Graphql.SelectionSet.map2 CurrentPage
+        endCursor
+        hasNextPage
+
+
+
+-- SelectionSet.empty
 
 
 {-| When paginating forwards, the cursor to continue.

--- a/examples/src/Github/Object/PageInfo.elm
+++ b/examples/src/Github/Object/PageInfo.elm
@@ -15,7 +15,7 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup exposing (CurrentPage, Direction(..))
+import Graphql.Pagination exposing (CurrentPage, Direction(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 

--- a/examples/src/Github/Object/Repository.elm
+++ b/examples/src/Github/Object/Repository.elm
@@ -991,11 +991,7 @@ stargazersPaginated :
     -> SelectionSet (PaginatedData decodesTo String) Github.Object.Repository
 stargazersPaginated pageSize paginator fillInOptionals object_ =
     stargazers (fillInOptionals >> Pagination.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
-        (Graphql.SelectionSet.map3 PaginatedData
-            (object_ |> Graphql.SelectionSet.map (\newList -> paginator.data ++ newList))
-            (Graphql.Internal.Paginator.fromSetup paginator.direction)
-            (Graphql.SelectionSet.succeed paginator.direction)
-        )
+        (Graphql.Internal.Paginator.selectionSet pageSize paginator object_)
 
 
 {-| Identifies the date and time when the object was last updated.

--- a/examples/src/Github/Object/Repository.elm
+++ b/examples/src/Github/Object/Repository.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Object.Repository exposing (AssignableUsersOptionalArguments, CollaboratorsOptionalArguments, CommitCommentsOptionalArguments, DeployKeysOptionalArguments, DeploymentsOptionalArguments, ForksOptionalArguments, IssueOrPullRequestRequiredArguments, IssueRequiredArguments, IssuesOptionalArguments, LabelRequiredArguments, LabelsOptionalArguments, LanguagesOptionalArguments, MentionableUsersOptionalArguments, MilestoneRequiredArguments, MilestonesOptionalArguments, ObjectOptionalArguments, ProjectRequiredArguments, ProjectsOptionalArguments, ProtectedBranchesOptionalArguments, PullRequestRequiredArguments, PullRequestsOptionalArguments, RefRequiredArguments, RefsOptionalArguments, RefsRequiredArguments, ReleaseRequiredArguments, ReleasesOptionalArguments, RepositoryTopicsOptionalArguments, ShortDescriptionHTMLOptionalArguments, StargazersOptionalArguments, WatchersOptionalArguments, assignableUsers, codeOfConduct, collaborators, commitComments, createdAt, databaseId, defaultBranchRef, deployKeys, deployments, description, descriptionHTML, diskUsage, forkCount, forks, hasIssuesEnabled, hasWikiEnabled, homepageUrl, id, isArchived, isFork, isLocked, isMirror, isPrivate, issue, issueOrPullRequest, issues, label, labels, languages, license, licenseInfo, lockReason, mentionableUsers, milestone, milestones, mirrorUrl, name, nameWithOwner, object, owner, parent, primaryLanguage, project, projects, projectsResourcePath, projectsUrl, protectedBranches, pullRequest, pullRequests, pushedAt, ref, refs, release, releases, repositoryTopics, resourcePath, shortDescriptionHTML, sshUrl, stargazers, updatedAt, url, viewerCanAdminister, viewerCanCreateProjects, viewerCanSubscribe, viewerCanUpdateTopics, viewerHasStarred, viewerPermission, viewerSubscription, watchers)
+module Github.Object.Repository exposing (AssignableUsersOptionalArguments, CollaboratorsOptionalArguments, CommitCommentsOptionalArguments, DeployKeysOptionalArguments, DeploymentsOptionalArguments, ForksOptionalArguments, IssueOrPullRequestRequiredArguments, IssueRequiredArguments, IssuesOptionalArguments, LabelRequiredArguments, LabelsOptionalArguments, LanguagesOptionalArguments, MentionableUsersOptionalArguments, MilestoneRequiredArguments, MilestonesOptionalArguments, ObjectOptionalArguments, ProjectRequiredArguments, ProjectsOptionalArguments, ProtectedBranchesOptionalArguments, PullRequestRequiredArguments, PullRequestsOptionalArguments, RefRequiredArguments, RefsOptionalArguments, RefsRequiredArguments, ReleaseRequiredArguments, ReleasesOptionalArguments, RepositoryTopicsOptionalArguments, ShortDescriptionHTMLOptionalArguments, StargazersOptionalArguments, WatchersOptionalArguments, assignableUsers, codeOfConduct, collaborators, commitComments, createdAt, databaseId, defaultBranchRef, deployKeys, deployments, description, descriptionHTML, diskUsage, forkCount, forks, hasIssuesEnabled, hasWikiEnabled, homepageUrl, id, isArchived, isFork, isLocked, isMirror, isPrivate, issue, issueOrPullRequest, issues, label, labels, languages, license, licenseInfo, lockReason, mentionableUsers, milestone, milestones, mirrorUrl, name, nameWithOwner, object, owner, parent, primaryLanguage, project, projects, projectsResourcePath, projectsUrl, protectedBranches, pullRequest, pullRequests, pushedAt, ref, refs, release, releases, repositoryTopics, resourcePath, shortDescriptionHTML, sshUrl, stargazers, stargazersPaginated, updatedAt, url, viewerCanAdminister, viewerCanCreateProjects, viewerCanSubscribe, viewerCanUpdateTopics, viewerHasStarred, viewerPermission, viewerSubscription, watchers)
 
 import Github.Enum.CollaboratorAffiliation
 import Github.Enum.IssueState
@@ -24,8 +24,10 @@ import Github.Union
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Internal.Paginator
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
+import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
@@ -979,6 +981,21 @@ stargazers fillInOptionals object_ =
                 |> List.filterMap identity
     in
     Object.selectionForCompositeField "stargazers" optionalArgs object_ identity
+
+
+stargazersPaginated :
+    Int
+    -> PaginatedData decodesTo String
+    -> (StargazersOptionalArguments -> StargazersOptionalArguments)
+    -> SelectionSet (List decodesTo) Github.Object.StargazerConnection
+    -> SelectionSet (PaginatedData decodesTo String) Github.Object.Repository
+stargazersPaginated pageSize paginator fillInOptionals object_ =
+    stargazers (fillInOptionals >> Pagination.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
+        (Graphql.SelectionSet.map3 PaginatedData
+            (object_ |> Graphql.SelectionSet.map (\newList -> paginator.data ++ newList))
+            (Graphql.Internal.Paginator.fromSetup paginator.direction)
+            (Graphql.SelectionSet.succeed paginator.direction)
+        )
 
 
 {-| Identifies the date and time when the object was last updated.

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Github.Query exposing (CodeOfConductRequiredArguments, LicenseRequiredArguments, MarketplaceCategoriesOptionalArguments, MarketplaceCategoryRequiredArguments, MarketplaceListingRequiredArguments, MarketplaceListingsOptionalArguments, NodeRequiredArguments, NodesRequiredArguments, OrganizationRequiredArguments, RateLimitOptionalArguments, RepositoryOwnerRequiredArguments, RepositoryRequiredArguments, ResourceRequiredArguments, SearchOptionalArguments, SearchRequiredArguments, TopicRequiredArguments, UserRequiredArguments, codeOfConduct, codesOfConduct, license, licenses, marketplaceCategories, marketplaceCategory, marketplaceListing, marketplaceListings, meta, node, nodes, organization, rateLimit, relay, repository, repositoryOwner, resource, search, topic, user, viewer)
+module Github.Query exposing (CodeOfConductRequiredArguments, LicenseRequiredArguments, MarketplaceCategoriesOptionalArguments, MarketplaceCategoryRequiredArguments, MarketplaceListingRequiredArguments, MarketplaceListingsOptionalArguments, NodeRequiredArguments, NodesRequiredArguments, OrganizationRequiredArguments, RateLimitOptionalArguments, RepositoryOwnerRequiredArguments, RepositoryRequiredArguments, ResourceRequiredArguments, SearchOptionalArguments, SearchRequiredArguments, TopicRequiredArguments, UserRequiredArguments, codeOfConduct, codesOfConduct, license, licenses, marketplaceCategories, marketplaceCategory, marketplaceListing, marketplaceListings, meta, node, nodes, organization, rateLimit, relay, repository, repositoryOwner, resource, search, searchPaginated, topic, user, viewer)
 
 import Github.Enum.SearchType
 import Github.InputObject
@@ -16,6 +16,7 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
+import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder)
 
@@ -328,6 +329,17 @@ search fillInOptionals requiredArgs object_ =
                 |> List.filterMap identity
     in
     Object.selectionForCompositeField "search" (optionalArgs ++ [ Argument.required "query" requiredArgs.query Encode.string, Argument.required "type" requiredArgs.type_ (Encode.enum Github.Enum.SearchType.toString) ]) object_ identity
+
+
+searchPaginated :
+    Maybe String
+    -> PaginatorSetup
+    -> (SearchOptionalArguments -> SearchOptionalArguments)
+    -> SearchRequiredArguments
+    -> SelectionSet decodesTo Github.Object.SearchResultItemConnection
+    -> SelectionSet decodesTo RootQuery
+searchPaginated cursor paginatorSetup fillInOptionals =
+    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
 
 
 type alias TopicRequiredArguments =

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -14,9 +14,10 @@ import Github.Union
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Internal.Paginator
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, PaginatedData, PaginatorSetup(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder)
 
@@ -337,7 +338,7 @@ searchPaginated :
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
     -> SelectionSet decodesTo Github.Object.SearchResultItemConnection
-    -> SelectionSet decodesTo RootQuery
+    -> SelectionSet (PaginatedData decodesTo String) RootQuery
 searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
     -- let
     --     foo =
@@ -347,7 +348,13 @@ searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
     --                 (Github.Object.PageInfo.fromSetup setup)
     --             )
     -- in
-    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup) requiredArgs object_
+    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
+        requiredArgs
+        (Graphql.SelectionSet.map2 PaginatedData
+            object_
+            -- (Github.Object.SearchResultItemConnection.pageInfo (Github.Object.PageInfo.fromSetup setup))
+            (Graphql.Internal.Paginator.fromSetup paginatorSetup)
+        )
 
 
 type alias TopicRequiredArguments =

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -337,22 +337,13 @@ searchPaginated :
     -> PaginatorSetup
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
-    -> SelectionSet decodesTo Github.Object.SearchResultItemConnection
+    -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection
     -> SelectionSet (PaginatedData decodesTo String) RootQuery
 searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
-    -- let
-    --     foo =
-    --         Graphql.SelectionSet.map2 Paginator
-    --             searchResultFieldEdges
-    --             (Github.Object.SearchResultItemConnection.pageInfo
-    --                 (Github.Object.PageInfo.fromSetup setup)
-    --             )
-    -- in
     search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
         requiredArgs
         (Graphql.SelectionSet.map2 PaginatedData
             object_
-            -- (Github.Object.SearchResultItemConnection.pageInfo (Github.Object.PageInfo.fromSetup setup))
             (Graphql.Internal.Paginator.fromSetup paginatorSetup)
         )
 

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -17,7 +17,7 @@ import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Internal.Paginator
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, Direction(..), PaginatedData)
+import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder)
 
@@ -340,7 +340,7 @@ searchPaginated :
     -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection
     -> SelectionSet (PaginatedData decodesTo String) RootQuery
 searchPaginated pageSize paginator fillInOptionals requiredArgs object_ =
-    search (fillInOptionals >> PaginatorSetup.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
+    search (fillInOptionals >> Pagination.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
         requiredArgs
         (Graphql.SelectionSet.map3 PaginatedData
             object_

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -334,7 +334,7 @@ search fillInOptionals requiredArgs object_ =
 
 searchPaginated :
     Int
-    -> PaginatedData any String
+    -> PaginatedData decodesTo String
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
     -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection
@@ -343,7 +343,7 @@ searchPaginated pageSize paginator fillInOptionals requiredArgs object_ =
     search (fillInOptionals >> Pagination.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
         requiredArgs
         (Graphql.SelectionSet.map3 PaginatedData
-            object_
+            (object_ |> Graphql.SelectionSet.map (\newList -> paginator.data ++ newList))
             (Graphql.Internal.Paginator.fromSetup paginator.direction)
             (Graphql.SelectionSet.succeed paginator.direction)
         )

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -333,14 +333,15 @@ search fillInOptionals requiredArgs object_ =
 
 
 searchPaginated :
-    Maybe String
+    Int
+    -> Maybe String
     -> Direction
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
     -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection
     -> SelectionSet (PaginatedData decodesTo String) RootQuery
-searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
-    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
+searchPaginated pageSize cursor paginatorSetup fillInOptionals requiredArgs object_ =
+    search (fillInOptionals >> PaginatorSetup.addPageInfo pageSize cursor paginatorSetup)
         requiredArgs
         (Graphql.SelectionSet.map3 PaginatedData
             object_

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -334,19 +334,18 @@ search fillInOptionals requiredArgs object_ =
 
 searchPaginated :
     Int
-    -> Maybe String
-    -> Direction
+    -> PaginatedData any String
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
     -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection
     -> SelectionSet (PaginatedData decodesTo String) RootQuery
-searchPaginated pageSize cursor paginatorSetup fillInOptionals requiredArgs object_ =
-    search (fillInOptionals >> PaginatorSetup.addPageInfo pageSize cursor paginatorSetup)
+searchPaginated pageSize paginator fillInOptionals requiredArgs object_ =
+    search (fillInOptionals >> PaginatorSetup.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
         requiredArgs
         (Graphql.SelectionSet.map3 PaginatedData
             object_
-            (Graphql.Internal.Paginator.fromSetup paginatorSetup)
-            (Graphql.SelectionSet.succeed paginatorSetup)
+            (Graphql.Internal.Paginator.fromSetup paginator.direction)
+            (Graphql.SelectionSet.succeed paginator.direction)
         )
 
 

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -342,11 +342,7 @@ searchPaginated :
 searchPaginated pageSize paginator fillInOptionals requiredArgs object_ =
     search (fillInOptionals >> Pagination.addPageInfo pageSize paginator.currentPage.cursor paginator.direction)
         requiredArgs
-        (Graphql.SelectionSet.map3 PaginatedData
-            (object_ |> Graphql.SelectionSet.map (\newList -> paginator.data ++ newList))
-            (Graphql.Internal.Paginator.fromSetup paginator.direction)
-            (Graphql.SelectionSet.succeed paginator.direction)
-        )
+        (Graphql.Internal.Paginator.selectionSet pageSize paginator object_)
 
 
 type alias TopicRequiredArguments =

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -342,9 +342,10 @@ searchPaginated :
 searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
     search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
         requiredArgs
-        (Graphql.SelectionSet.map2 PaginatedData
+        (Graphql.SelectionSet.map3 PaginatedData
             object_
             (Graphql.Internal.Paginator.fromSetup paginatorSetup)
+            (Graphql.SelectionSet.succeed paginatorSetup)
         )
 
 

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -338,8 +338,16 @@ searchPaginated :
     -> SearchRequiredArguments
     -> SelectionSet decodesTo Github.Object.SearchResultItemConnection
     -> SelectionSet decodesTo RootQuery
-searchPaginated cursor paginatorSetup fillInOptionals =
-    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup)
+searchPaginated cursor paginatorSetup fillInOptionals requiredArgs object_ =
+    -- let
+    --     foo =
+    --         Graphql.SelectionSet.map2 Paginator
+    --             searchResultFieldEdges
+    --             (Github.Object.SearchResultItemConnection.pageInfo
+    --                 (Github.Object.PageInfo.fromSetup setup)
+    --             )
+    -- in
+    search (fillInOptionals >> PaginatorSetup.addPageInfo cursor paginatorSetup) requiredArgs object_
 
 
 type alias TopicRequiredArguments =

--- a/examples/src/Github/Query.elm
+++ b/examples/src/Github/Query.elm
@@ -17,7 +17,7 @@ import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Internal.Paginator
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, PaginatedData, PaginatorSetup(..))
+import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder)
 
@@ -334,7 +334,7 @@ search fillInOptionals requiredArgs object_ =
 
 searchPaginated :
     Maybe String
-    -> PaginatorSetup
+    -> Direction
     -> (SearchOptionalArguments -> SearchOptionalArguments)
     -> SearchRequiredArguments
     -> SelectionSet (List decodesTo) Github.Object.SearchResultItemConnection

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -78,6 +78,25 @@ query cursor =
         )
 
 
+newThing cursor =
+    let
+        setup =
+            Forward { first = 1 }
+    in
+    Query.searchPaginated cursor
+        setup
+        identity
+        { query = "language:Elm"
+        , type_ = Github.Enum.SearchType.Repository
+        }
+        (SelectionSet.map2 Paginator
+            searchResultFieldEdges
+            (Github.Object.SearchResultItemConnection.pageInfo
+                (Github.Object.PageInfo.fromSetup setup)
+            )
+        )
+
+
 searchResultFieldEdges : SelectionSet (List Repo) Github.Object.SearchResultItemConnection
 searchResultFieldEdges =
     Github.Object.SearchResultItemConnection.edges

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -41,8 +41,7 @@ query paginator =
             Forward
     in
     Query.searchPaginated 1
-        paginator.currentPage.cursor
-        paginator.direction
+        paginator
         identity
         { query = "language:Elm", type_ = Github.Enum.SearchType.Repository }
         searchResultFieldEdges

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -16,7 +16,7 @@ import Graphql.Document as Document
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+import Graphql.PaginatorSetup exposing (CurrentPage, PaginatedData, PaginatorSetup(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (button, div, h1, p, pre, text)
 import Html.Events exposing (onClick)
@@ -25,13 +25,7 @@ import RemoteData exposing (RemoteData)
 
 
 type alias Response =
-    Paginator (List Repo) String
-
-
-type alias Paginator dataType cursorType =
-    { data : dataType
-    , paginationData : CurrentPage cursorType
-    }
+    PaginatedData (List Repo) String
 
 
 
@@ -70,7 +64,7 @@ query cursor =
         { query = "language:Elm"
         , type_ = Github.Enum.SearchType.Repository
         }
-        (SelectionSet.map2 Paginator
+        (SelectionSet.map2 PaginatedData
             searchResultFieldEdges
             (Github.Object.SearchResultItemConnection.pageInfo
                 (Github.Object.PageInfo.fromSetup setup)
@@ -89,7 +83,7 @@ newThing cursor =
         { query = "language:Elm"
         , type_ = Github.Enum.SearchType.Repository
         }
-        (SelectionSet.map2 Paginator
+        (SelectionSet.map2 PaginatedData
             searchResultFieldEdges
             (Github.Object.SearchResultItemConnection.pageInfo
                 (Github.Object.PageInfo.fromSetup setup)
@@ -184,8 +178,8 @@ update msg model =
         GetNextPage ->
             case model of
                 (RemoteData.Success successResponse) :: rest ->
-                    if successResponse.paginationData.done then
-                        ( RemoteData.Loading :: model, makeRequest successResponse.paginationData.cursor )
+                    if successResponse.currentPage.done then
+                        ( RemoteData.Loading :: model, makeRequest successResponse.currentPage.cursor )
 
                     else
                         ( model, Cmd.none )

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -62,9 +62,7 @@ query cursor =
     Query.searchPaginated cursor
         setup
         identity
-        { query = "language:Elm"
-        , type_ = Github.Enum.SearchType.Repository
-        }
+        { query = "language:Elm", type_ = Github.Enum.SearchType.Repository }
         searchResultFieldEdges
 
 

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -59,36 +59,13 @@ query cursor =
         setup =
             Forward { first = 1 }
     in
-    Query.search
-        (paginationArguments cursor setup)
-        { query = "language:Elm"
-        , type_ = Github.Enum.SearchType.Repository
-        }
-        (SelectionSet.map2 PaginatedData
-            searchResultFieldEdges
-            (Github.Object.SearchResultItemConnection.pageInfo
-                (Github.Object.PageInfo.fromSetup setup)
-            )
-        )
-
-
-newThing cursor =
-    let
-        setup =
-            Forward { first = 1 }
-    in
     Query.searchPaginated cursor
         setup
         identity
         { query = "language:Elm"
         , type_ = Github.Enum.SearchType.Repository
         }
-        (SelectionSet.map2 PaginatedData
-            searchResultFieldEdges
-            (Github.Object.SearchResultItemConnection.pageInfo
-                (Github.Object.PageInfo.fromSetup setup)
-            )
-        )
+        searchResultFieldEdges
 
 
 searchResultFieldEdges : SelectionSet (List Repo) Github.Object.SearchResultItemConnection

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -61,40 +61,21 @@ paginationArguments maybeCursor paginationSetup optionals =
 
 query : Maybe String -> SelectionSet Response RootQuery
 query cursor =
+    let
+        setup =
+            Forward { first = 1 }
+    in
     Query.search
-        (paginationArguments cursor (Forward { first = 1 }))
+        (paginationArguments cursor setup)
         { query = "language:Elm"
         , type_ = Github.Enum.SearchType.Repository
         }
         (SelectionSet.map2 Paginator
             searchResultFieldEdges
             (Github.Object.SearchResultItemConnection.pageInfo
-                (Github.Object.PageInfo.fromSetup (Forward { first = 1 }))
+                (Github.Object.PageInfo.fromSetup setup)
             )
         )
-
-
-searchSelection : SelectionSet Response Github.Object.SearchResultItemConnection
-searchSelection =
-    SelectionSet.map2 Paginator
-        searchResultFieldEdges
-        (Github.Object.SearchResultItemConnection.pageInfo searchPageInfoSelection)
-
-
-searchPageInfoSelection : SelectionSet (CurrentPage String) Github.Object.PageInfo
-searchPageInfoSelection =
-    -- SelectionSet.succeed PaginationData
-    --     |> with Github.Object.PageInfo.endCursor
-    --     |> with Github.Object.PageInfo.hasNextPage
-    Github.Object.PageInfo.fromSetup (Forward { first = 1 })
-
-
-searchResultFieldNodes : SelectionSet (List Repo) Github.Object.SearchResultItemConnection
-searchResultFieldNodes =
-    Github.Object.SearchResultItemConnection.nodes searchResultSelection
-        |> SelectionSet.nonNullOrFail
-        |> SelectionSet.nonNullElementsOrFail
-        |> SelectionSet.nonNullElementsOrFail
 
 
 searchResultFieldEdges : SelectionSet (List Repo) Github.Object.SearchResultItemConnection

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -16,7 +16,7 @@ import Graphql.Document as Document
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, PaginatedData, PaginatorSetup(..))
+import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (button, div, h1, p, pre, text)
 import Html.Events exposing (onClick)

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -27,12 +27,6 @@ type alias Response =
     PaginatedData Repo String
 
 
-
--- first query -> No Cursor, just count (first or last)
--- Result comes back -> Get a cursor, maintain the count
--- second query, Cursor, no count (use from previous)
-
-
 query : Int -> PaginatedData Repo String -> SelectionSet Response RootQuery
 query pageSize paginator =
     let

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -16,7 +16,7 @@ import Graphql.Document as Document
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup as PaginatorSetup exposing (CurrentPage, Direction(..), PaginatedData)
+import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (button, div, h1, input, p, pre, text)
 import Html.Events exposing (onClick)
@@ -122,7 +122,7 @@ type alias RemoteDataResponse =
 
 init : Flags -> ( Model, Cmd Msg )
 init flags =
-    PaginatorSetup.init Forward [ RemoteData.Loading ]
+    Pagination.init Forward [ RemoteData.Loading ]
         |> (\paginator ->
                 ( { pageSize = 1
                   , data = paginator

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -33,6 +33,25 @@ type alias Paginator dataType cursorType =
     }
 
 
+
+-- first query -> No Cursor, just count (first or last)
+-- Result comes back -> Get a cursor, maintain the count
+-- second query, Cursor, no count (use from previous)
+
+
+type PaginationContinuation cursor
+    = Forward { first : Int } { after : cursor }
+    | Backward { last : Int } { before : cursor }
+
+
+paginationArguments : Maybe String -> Query.SearchOptionalArguments -> Query.SearchOptionalArguments
+paginationArguments maybeCursor optionals =
+    { optionals
+        | first = Present 1
+        , after = OptionalArgument.fromMaybe maybeCursor
+    }
+
+
 query : Maybe String -> SelectionSet Response RootQuery
 query cursor =
     Query.search

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -32,25 +32,6 @@ type alias Response =
 -- first query -> No Cursor, just count (first or last)
 -- Result comes back -> Get a cursor, maintain the count
 -- second query, Cursor, no count (use from previous)
--- type PaginationContinuation cursor
---     = Forward { first : Int } { after : cursor }
---     | Backward { last : Int } { before : cursor }
-
-
-paginationArguments : Maybe String -> PaginatorSetup -> Query.SearchOptionalArguments -> Query.SearchOptionalArguments
-paginationArguments maybeCursor paginationSetup optionals =
-    case paginationSetup of
-        Forward { first } ->
-            { optionals
-                | first = Present first
-                , after = OptionalArgument.fromMaybe maybeCursor
-            }
-
-        Backward { last } ->
-            { optionals
-                | last = Present last
-                , before = OptionalArgument.fromMaybe maybeCursor
-            }
 
 
 query : Maybe String -> SelectionSet Response RootQuery

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -167,7 +167,7 @@ view model =
         , div [] [ button [ onClick GetNextPage ] [ text "Load next page..." ] ]
         , div []
             [ h1 [] [ text "Response" ]
-            , PrintAny.view model
+            , PrintAny.view (model |> List.reverse)
             ]
         ]
 

--- a/examples/src/GithubPagination.elm
+++ b/examples/src/GithubPagination.elm
@@ -25,7 +25,7 @@ import RemoteData exposing (RemoteData)
 
 
 type alias Response =
-    PaginatedData (List Repo) String
+    PaginatedData Repo String
 
 
 

--- a/examples/src/GithubPagination2.elm
+++ b/examples/src/GithubPagination2.elm
@@ -20,7 +20,7 @@ import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
 import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (button, div, h1, input, p, pre, text)
+import Html exposing (Html, button, div, h1, input, p, pre, text)
 import Html.Events exposing (onClick)
 import PrintAny
 
@@ -99,7 +99,7 @@ init flags =
            )
 
 
-view : Model -> Html.Html Msg
+view : Model -> Html Msg
 view model =
     div []
         [ div []
@@ -110,12 +110,28 @@ view model =
         , div []
             [ button [ onClick GetNextPage ] [ text <| "Load next " ++ String.fromInt model.pageSize ++ " item(s)..." ]
             , input [ Html.Events.onInput CountChanged ] []
+            , paginationDetailsView model
             ]
         , div []
             [ h1 [] [ text "Response" ]
             , PrintAny.view (model.data.data |> List.reverse)
             ]
         ]
+
+
+paginationDetailsView : Model -> Html msg
+paginationDetailsView model =
+    doneView model
+
+
+doneView model =
+    Html.text
+        (if model.data.currentPage.hasNextPage then
+            "Loading..."
+
+         else
+            "✅"
+        )
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/examples/src/GithubPagination2.elm
+++ b/examples/src/GithubPagination2.elm
@@ -1,0 +1,149 @@
+module GithubPagination2 exposing (main)
+
+import Browser
+import Github.Enum.SearchType
+import Github.Object
+import Github.Object.PageInfo
+import Github.Object.Repository as Repository
+import Github.Object.SearchResultItemConnection
+import Github.Object.SearchResultItemEdge
+import Github.Object.StargazerConnection
+import Github.Object.StargazerEdge
+import Github.Object.User
+import Github.Query as Query
+import Github.Scalar
+import Github.Union
+import Github.Union.SearchResultItem
+import Graphql.Document as Document
+import Graphql.Http
+import Graphql.Operation exposing (RootQuery)
+import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
+import Html exposing (button, div, h1, input, p, pre, text)
+import Html.Events exposing (onClick)
+import PrintAny
+
+
+type alias Response =
+    PaginatedData StarGazer String
+
+
+query : Int -> PaginatedData StarGazer String -> SelectionSet Response RootQuery
+query pageSize paginator =
+    let
+        setup =
+            Forward
+    in
+    Query.repository { owner = "dillonkearns", name = "elm-graphql" }
+        (Repository.stargazersPaginated
+            pageSize
+            paginator
+            identity
+            stargazerSelection
+        )
+        |> SelectionSet.nonNullOrFail
+
+
+stargazerSelection : SelectionSet (List String) Github.Object.StargazerConnection
+stargazerSelection =
+    Github.Object.StargazerConnection.edges (Github.Object.StargazerEdge.node (Github.Object.User.name |> SelectionSet.withDefault "???"))
+        |> SelectionSet.nonNullOrFail
+        |> SelectionSet.nonNullElementsOrFail
+
+
+type alias StarGazer =
+    String
+
+
+makeRequest : Int -> PaginatedData StarGazer String -> Cmd Msg
+makeRequest pageSize paginator =
+    query pageSize paginator
+        |> Graphql.Http.queryRequest "https://api.github.com/graphql"
+        |> Graphql.Http.withHeader "authorization" "Bearer dbd4c239b0bbaa40ab0ea291fa811775da8f5b59"
+        |> Graphql.Http.send GotResponse
+
+
+type Msg
+    = GotResponse RemoteDataResponse
+    | GetNextPage
+    | CountChanged String
+
+
+type alias Model =
+    -- List RemoteDataResponse
+    { pageSize : Int
+    , data : PaginatedData StarGazer String
+    }
+
+
+type alias RemoteDataResponse =
+    Result (Graphql.Http.Error Response) Response
+
+
+init : Flags -> ( Model, Cmd Msg )
+init flags =
+    Pagination.init Forward []
+        |> (\paginator ->
+                ( { pageSize = 1
+                  , data = paginator
+                  }
+                , makeRequest 1 paginator
+                )
+           )
+
+
+view : Model -> Html.Html Msg
+view model =
+    div []
+        [ div []
+            [ h1 [] [ text "Generated Query" ]
+
+            -- , pre [] [ text (Document.serializeQuery (query model.pageSize model.data)) ]
+            ]
+        , div []
+            [ button [ onClick GetNextPage ] [ text <| "Load next " ++ String.fromInt model.pageSize ++ " item(s)..." ]
+            , input [ Html.Events.onInput CountChanged ] []
+            ]
+        , div []
+            [ h1 [] [ text "Response" ]
+            , PrintAny.view (model.data.data |> List.reverse)
+            ]
+        ]
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        GetNextPage ->
+            ( model, makeRequest model.pageSize model.data )
+
+        GotResponse response ->
+            case response of
+                Ok successData ->
+                    ( { model | data = successData }, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
+
+        CountChanged newPageSizeString ->
+            case newPageSizeString |> String.toInt of
+                Just newPageSize ->
+                    ( { model | pageSize = newPageSize }, Cmd.none )
+
+                Nothing ->
+                    ( model, Cmd.none )
+
+
+type alias Flags =
+    ()
+
+
+main : Program Flags Model Msg
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , subscriptions = \_ -> Sub.none
+        , view = view
+        }

--- a/examples/src/GithubPagination2.elm
+++ b/examples/src/GithubPagination2.elm
@@ -121,16 +121,25 @@ view model =
 
 paginationDetailsView : Model -> Html msg
 paginationDetailsView model =
-    doneView model
+    div []
+        [ "Loaded "
+            ++ (model.data.data
+                    |> List.length
+                    |> String.fromInt
+               )
+            ++ " so far"
+            |> text
+        , doneView model
+        ]
 
 
 doneView model =
     Html.text
         (if model.data.currentPage.hasNextPage then
-            "Loading..."
+            "..."
 
          else
-            "✅"
+            " ✅"
         )
 
 

--- a/src/Graphql/Internal/Paginator.elm
+++ b/src/Graphql/Internal/Paginator.elm
@@ -1,0 +1,45 @@
+module Graphql.Internal.Paginator exposing (fromSetup)
+
+import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
+import Graphql.Internal.Builder.Object as Object
+import Graphql.Internal.Encode as Encode exposing (Value)
+import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
+import Graphql.OptionalArgument exposing (OptionalArgument(..))
+import Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+import Graphql.SelectionSet exposing (SelectionSet)
+import Json.Decode as Decode
+
+
+fromSetup : PaginatorSetup -> SelectionSet (CurrentPage String) pageInfo
+fromSetup paginatorSetup =
+    Graphql.SelectionSet.map2 CurrentPage
+        endCursor
+        hasNextPage
+
+
+{-| When paginating forwards, the cursor to continue.
+-}
+endCursor : SelectionSet (Maybe String) pageInfo
+endCursor =
+    Object.selectionForField "(Maybe String)" "endCursor" [] (Decode.string |> Decode.nullable)
+
+
+{-| When paginating forwards, are there more items?
+-}
+hasNextPage : SelectionSet Bool pageInfo
+hasNextPage =
+    Object.selectionForField "Bool" "hasNextPage" [] Decode.bool
+
+
+{-| When paginating backwards, are there more items?
+-}
+hasPreviousPage : SelectionSet Bool pageInfo
+hasPreviousPage =
+    Object.selectionForField "Bool" "hasPreviousPage" [] Decode.bool
+
+
+{-| When paginating backwards, the cursor to continue.
+-}
+startCursor : SelectionSet (Maybe String) pageInfo
+startCursor =
+    Object.selectionForField "(Maybe String)" "startCursor" [] (Decode.string |> Decode.nullable)

--- a/src/Graphql/Internal/Paginator.elm
+++ b/src/Graphql/Internal/Paginator.elm
@@ -10,11 +10,15 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-fromSetup : Direction -> SelectionSet (CurrentPage String) pageInfo
+fromSetup : Direction -> SelectionSet (CurrentPage String) connection
 fromSetup paginatorSetup =
-    Graphql.SelectionSet.map2 CurrentPage
-        endCursor
-        hasNextPage
+    let
+        object_ =
+            Graphql.SelectionSet.map2 CurrentPage
+                endCursor
+                hasNextPage
+    in
+    Object.selectionForCompositeField "pageInfo" [] object_ identity
 
 
 {-| When paginating forwards, the cursor to continue.

--- a/src/Graphql/Internal/Paginator.elm
+++ b/src/Graphql/Internal/Paginator.elm
@@ -5,12 +5,12 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+import Graphql.PaginatorSetup exposing (CurrentPage, Direction(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-fromSetup : PaginatorSetup -> SelectionSet (CurrentPage String) pageInfo
+fromSetup : Direction -> SelectionSet (CurrentPage String) pageInfo
 fromSetup paginatorSetup =
     Graphql.SelectionSet.map2 CurrentPage
         endCursor

--- a/src/Graphql/Internal/Paginator.elm
+++ b/src/Graphql/Internal/Paginator.elm
@@ -5,7 +5,7 @@ import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.PaginatorSetup exposing (CurrentPage, Direction(..))
+import Graphql.Pagination exposing (CurrentPage, Direction(..))
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 

--- a/src/Graphql/Internal/Paginator.elm
+++ b/src/Graphql/Internal/Paginator.elm
@@ -1,13 +1,25 @@
-module Graphql.Internal.Paginator exposing (fromSetup)
+module Graphql.Internal.Paginator exposing (fromSetup, selectionSet)
 
 import Graphql.Internal.Builder.Argument as Argument exposing (Argument)
 import Graphql.Internal.Builder.Object as Object
 import Graphql.Internal.Encode as Encode exposing (Value)
 import Graphql.Operation exposing (RootMutation, RootQuery, RootSubscription)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.Pagination exposing (CurrentPage, Direction(..))
+import Graphql.Pagination as Pagination exposing (CurrentPage, Direction(..), PaginatedData)
 import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
+
+
+selectionSet :
+    Int
+    -> PaginatedData decodesTo String
+    -> SelectionSet (List decodesTo) typeLock
+    -> SelectionSet (PaginatedData decodesTo String) typeLock
+selectionSet pageSize paginator selection =
+    Graphql.SelectionSet.map3 PaginatedData
+        (selection |> Graphql.SelectionSet.map (\newList -> paginator.data ++ newList))
+        (fromSetup paginator.direction)
+        (Graphql.SelectionSet.succeed paginator.direction)
 
 
 fromSetup : Direction -> SelectionSet (CurrentPage String) connection

--- a/src/Graphql/Pagination.elm
+++ b/src/Graphql/Pagination.elm
@@ -6,7 +6,7 @@ import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(.
 init : Direction -> List data -> PaginatedData data cursor
 init direction initialData =
     { data = initialData
-    , currentPage = { cursor = Nothing, done = False }
+    , currentPage = { cursor = Nothing, hasNextPage = True }
     , direction = direction
     }
 
@@ -54,5 +54,5 @@ type Direction
 
 type alias CurrentPage cursorType =
     { cursor : Maybe cursorType
-    , done : Bool
+    , hasNextPage : Bool
     }

--- a/src/Graphql/Pagination.elm
+++ b/src/Graphql/Pagination.elm
@@ -4,10 +4,10 @@ import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(.
 
 
 init : Direction -> List data -> PaginatedData data cursor
-init paginatorSetup initialData =
+init direction initialData =
     { data = initialData
     , currentPage = { cursor = Nothing, done = False }
-    , direction = paginatorSetup
+    , direction = direction
     }
 
 

--- a/src/Graphql/Pagination.elm
+++ b/src/Graphql/Pagination.elm
@@ -1,4 +1,4 @@
-module Graphql.PaginatorSetup exposing (CurrentPage, Direction(..), PageInfo, PaginatedData, addPageInfo, init)
+module Graphql.Pagination exposing (CurrentPage, Direction(..), PageInfo, PaginatedData, addPageInfo, init)
 
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
 

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -1,0 +1,17 @@
+module Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+
+{-| TODO
+-}
+
+
+{-| Uses [the relay protocol](https://facebook.github.io/relay/graphql/connections.htm).
+-}
+type PaginatorSetup
+    = Forward { first : Int }
+    | Backward { last : Int }
+
+
+type alias CurrentPage cursorType =
+    { cursor : Maybe cursorType
+    , done : Bool
+    }

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -6,6 +6,7 @@ import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(.
 type alias PaginatedData data cursor =
     { data : List data
     , currentPage : CurrentPage cursor
+    , setup : PaginatorSetup
     }
 
 

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -1,6 +1,12 @@
-module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatorSetup(..), addPageInfo)
+module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatedData, PaginatorSetup(..), addPageInfo)
 
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+
+
+type alias PaginatedData data cursor =
+    { data : data
+    , currentPage : CurrentPage cursor
+    }
 
 
 type alias PageInfo pageInfo cursor =

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -1,9 +1,9 @@
-module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatedData, PaginatorSetup(..), addPageInfo, init)
+module Graphql.PaginatorSetup exposing (CurrentPage, Direction(..), PageInfo, PaginatedData, addPageInfo, init)
 
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
 
 
-init : PaginatorSetup -> List data -> PaginatedData data cursor
+init : Direction -> List data -> PaginatedData data cursor
 init paginatorSetup initialData =
     { data = initialData
     , currentPage = { cursor = Nothing, done = False }
@@ -14,7 +14,7 @@ init paginatorSetup initialData =
 type alias PaginatedData data cursor =
     { data : List data
     , currentPage : CurrentPage cursor
-    , setup : PaginatorSetup
+    , setup : Direction
     }
 
 
@@ -29,7 +29,7 @@ type alias PageInfo pageInfo cursor =
 
 {-| TODO
 -}
-addPageInfo : Maybe cursor -> PaginatorSetup -> PageInfo pageInfo cursor -> PageInfo pageInfo cursor
+addPageInfo : Maybe cursor -> Direction -> PageInfo pageInfo cursor -> PageInfo pageInfo cursor
 addPageInfo maybeCursor paginationSetup optionals =
     case paginationSetup of
         Forward { first } ->
@@ -47,7 +47,7 @@ addPageInfo maybeCursor paginationSetup optionals =
 
 {-| Uses [the relay protocol](https://facebook.github.io/relay/graphql/connections.htm).
 -}
-type PaginatorSetup
+type Direction
     = Forward { first : Int }
     | Backward { last : Int }
 

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -4,7 +4,7 @@ import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(.
 
 
 type alias PaginatedData data cursor =
-    { data : data
+    { data : List data
     , currentPage : CurrentPage cursor
     }
 

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -7,14 +7,14 @@ init : Direction -> List data -> PaginatedData data cursor
 init paginatorSetup initialData =
     { data = initialData
     , currentPage = { cursor = Nothing, done = False }
-    , setup = paginatorSetup
+    , direction = paginatorSetup
     }
 
 
 type alias PaginatedData data cursor =
     { data : List data
     , currentPage : CurrentPage cursor
-    , setup : Direction
+    , direction : Direction
     }
 
 
@@ -29,18 +29,18 @@ type alias PageInfo pageInfo cursor =
 
 {-| TODO
 -}
-addPageInfo : Maybe cursor -> Direction -> PageInfo pageInfo cursor -> PageInfo pageInfo cursor
-addPageInfo maybeCursor paginationSetup optionals =
+addPageInfo : Int -> Maybe cursor -> Direction -> PageInfo pageInfo cursor -> PageInfo pageInfo cursor
+addPageInfo pageSize maybeCursor paginationSetup optionals =
     case paginationSetup of
-        Forward { first } ->
+        Forward ->
             { optionals
-                | first = Present first
+                | first = Present pageSize
                 , after = OptionalArgument.fromMaybe maybeCursor
             }
 
-        Backward { last } ->
+        Backward ->
             { optionals
-                | last = Present last
+                | last = Present pageSize
                 , before = OptionalArgument.fromMaybe maybeCursor
             }
 
@@ -48,8 +48,8 @@ addPageInfo maybeCursor paginationSetup optionals =
 {-| Uses [the relay protocol](https://facebook.github.io/relay/graphql/connections.htm).
 -}
 type Direction
-    = Forward { first : Int }
-    | Backward { last : Int }
+    = Forward
+    | Backward
 
 
 type alias CurrentPage cursorType =

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -1,6 +1,14 @@
-module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatedData, PaginatorSetup(..), addPageInfo)
+module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatedData, PaginatorSetup(..), addPageInfo, init)
 
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+
+
+init : PaginatorSetup -> List data -> PaginatedData data cursor
+init paginatorSetup initialData =
+    { data = initialData
+    , currentPage = { cursor = Nothing, done = False }
+    , setup = paginatorSetup
+    }
 
 
 type alias PaginatedData data cursor =

--- a/src/Graphql/PaginatorSetup.elm
+++ b/src/Graphql/PaginatorSetup.elm
@@ -1,7 +1,33 @@
-module Graphql.PaginatorSetup exposing (CurrentPage, PaginatorSetup(..))
+module Graphql.PaginatorSetup exposing (CurrentPage, PageInfo, PaginatorSetup(..), addPageInfo)
+
+import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
+
+
+type alias PageInfo pageInfo cursor =
+    { pageInfo
+        | first : OptionalArgument Int
+        , last : OptionalArgument Int
+        , before : OptionalArgument cursor
+        , after : OptionalArgument cursor
+    }
+
 
 {-| TODO
 -}
+addPageInfo : Maybe cursor -> PaginatorSetup -> PageInfo pageInfo cursor -> PageInfo pageInfo cursor
+addPageInfo maybeCursor paginationSetup optionals =
+    case paginationSetup of
+        Forward { first } ->
+            { optionals
+                | first = Present first
+                , after = OptionalArgument.fromMaybe maybeCursor
+            }
+
+        Backward { last } ->
+            { optionals
+                | last = Present last
+                , before = OptionalArgument.fromMaybe maybeCursor
+            }
 
 
 {-| Uses [the relay protocol](https://facebook.github.io/relay/graphql/connections.htm).


### PR DESCRIPTION
# Adding Relay Pagination to `elm-graphql`

## Guiding Goals
* Make it impossible to do the wrong thing
* Make it easy to do the right thing - ideally, we can give just one nice API that disallows using the low-level pagination directly, and instead gives you a high-level interface. This will be less confusing and less error-prone. But having the low-level available could potentially be an escape hatch, so it might be an option to consider.

* Make Impossible States Impossible - it would be awesome if it was impossible to make invalid pagination requests. It's common to get runtime exceptions with APIs if you 1) forget to pass in pagination arguments (but perhaps some APIs allow you to paginate or not... Github for example will fail if you're not explicit), 2) pass in both Forward and Backward pagination arguments (though it's not technically illegal in the Relay spec, it's strongly discouraged... let's just assume it's illegal).
Let's also eliminate things like 3) changing directions midway through paginating. And 4) let's make it impossible to update just the new data, but not update the cursor. You update them all atomically. This can be accomplished by passing in a data structure that includes the list of data so far, plus the pagination data. The selection set will add on to that data structure and update the pagination data with its response.


## References
* The official [Relay Cursor Connections Specification document](https://facebook.github.io/relay/graphql/connections.htm)
* An [example using Relay on the client-side](https://facebook.github.io/relay/docs/en/pagination-container.html#loadmore)

## Open questions

* The Relay Spec says you should be able to pass in `first` and `last`. See [this note in the official spec](https://facebook.github.io/relay/graphql/connections.htm#sec-Pagination-algorithm).
* What should the API look like if there is only a `first` or a `last`? Should the Paginator argument be a `Maybe`??? Or would that cause some unwanted corner cases and more confusing API?
* Should we support having neither a `first` or a `last` if there are arguments for that? Do some APIs have pagination arguments but not use them? TODO look for examples.
* Can we make some sort of RemoteData equivalent that captures the possible pagination data states?
* Is it a valid use case to get back a response that says `hasNextPage` is `false`, and then try it again later to check if any new data has been added since? I think it should be probably.


## Possible strategies
### Allow CLI Flag to Skip Relay Generation
Pros
* Allows you to opt-out of 
* Will most likely do the "right thing" for most users (unless I'm missing something?)
* Allows elimination of impossible states

Cons
* All or nothing. Either you follow the Relay spec and can use it, or you don't and can't get any of the benefits. This is probably reasonable. It would be good to give users a warning if they don't follow the Relay specification despite similar naming... tell them exactly what is preventing it from being considered a Relay schema. If you supply a flag, like `--fail-on-relay-schema-violation` then it will exit the CLI if there is a violation with non-zero exit status.
* The code generation code will be a little bit more complicated

### Allow both low-level access and high-level access.
Pros
* Simple in that it does the same thing no matter what for all schemas

Cons
* Harder to discover the pagination helpers potentially
* Larger generated API so more confusing
* Doesn't eliminate possible states