### PR TITLE
Don't alias __typename

### DIFF
--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -51,9 +51,11 @@ alias field =
         -- assumes it won't be
         Leaf { typeString, fieldName } arguments ->
             if fieldName == "__typename" then
-                Just "__typename"
+                Nothing
+
             else
-               defaultAlias
+                defaultAlias
+
         _ ->
             defaultAlias
 

--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -39,9 +39,23 @@ maybeAliasHash field =
 
 alias : RawField -> Maybe String
 alias field =
-    field
-        |> maybeAliasHash
-        |> Maybe.map (\aliasHash -> Graphql.RawField.name field ++ aliasHash)
+    let
+        defaultAlias =
+            field
+                |> maybeAliasHash
+                |> Maybe.map (\aliasHash -> Graphql.RawField.name field ++ aliasHash)
+    in
+    case field of
+        -- __typename is a special beast which needn't be aliased,
+        -- and if aliased, may cause trouble for tooling which
+        -- assumes it won't be
+        Leaf { typeString, fieldName } arguments ->
+            if fieldName == "__typename" then
+                Just "__typename"
+            else
+               defaultAlias
+        _ ->
+            defaultAlias
 
 
 serialize : Maybe String -> Maybe Int -> RawField -> Maybe String

--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -14,7 +14,7 @@ hashedAliasName field =
         |> Maybe.withDefault (Graphql.RawField.name field)
 
 
-maybeAliasHash : RawField -> Maybe String
+maybeAliasHash : RawField -> Maybe Int
 maybeAliasHash field =
     (case field of
         Composite name arguments children ->
@@ -41,14 +41,14 @@ maybeAliasHash field =
                     |> String.concat
                     |> Just
     )
-        |> Maybe.map (Murmur3.hashString 0 >> String.fromInt)
+        |> Maybe.map (Murmur3.hashString 0)
 
 
 alias : RawField -> Maybe String
 alias field =
     field
         |> maybeAliasHash
-        |> Maybe.map (\aliasHash -> Graphql.RawField.name field ++ aliasHash)
+        |> Maybe.map (\aliasHash -> Graphql.RawField.name field ++ String.fromInt aliasHash)
 
 
 serialize : Maybe String -> Maybe Int -> RawField -> Maybe String

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -100,7 +100,7 @@ all =
                     |> Expect.equal """query {
   topLevel {
     ...on Droid {
-      __typename0: __typename
+      __typename
     }
   }
 }"""
@@ -110,7 +110,7 @@ all =
                     document []
                         |> Graphql.Document.serializeQuery
                         |> Expect.equal """query {
-  __typename0: __typename
+  __typename
 }"""
             , test "nested empty query" <|
                 \() ->
@@ -120,7 +120,7 @@ all =
                         |> Graphql.Document.serializeQuery
                         |> Expect.equal """query {
   viewer {
-    __typename0: __typename
+    __typename
   }
 }"""
             ]


### PR DESCRIPTION
This fixes issue #120 by selectively modifying the alias function to not alias `__typename`. There may be a better way to tackle the issue, but this works in my case as is.