### PR TITLE
Add reference to Hasura elm-graphql course

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ elm-graphql https://elm-graphql.herokuapp.com --base StarWars --output examples/
 * There are a couple of chapters so far in [The Official `dillonkearns/elm-graphql` Gitbook](https://dillonkearns.gitbooks.io/elm-graphql/content/)
 * [A Beginner's Guide to GraphQL with Elm](https://medium.com/@zenitram.oiram/a-beginners-guide-to-graphql-with-elm-315b580f0aad) by [@martimatix](https://github.com/martimatix)
 * [Graphqelm: Optional Arguments in a Language Without Optional Arguments](https://medium.com/@zenitram.oiram/graphqelm-optional-arguments-in-a-language-without-optional-arguments-d8074ca3cf74) by [@martimatix](https://github.com/martimatix)
-* [Compehensive tutorial by the Hasura Team](https://learn.hasura.io/graphql/elm-graphql/introduction)
+* [Comprehensive tutorial by the Hasura Team](https://learn.hasura.io/graphql/elm-graphql/introduction)
 
 If you're wondering why code is generated a certain way, you're likely to find an answer in the [Frequently Asked Questions (FAQ)](https://github.com/dillonkearns/elm-graphql/blob/master/FAQ.md).
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ elm-graphql https://elm-graphql.herokuapp.com --base StarWars --output examples/
 * There are a couple of chapters so far in [The Official `dillonkearns/elm-graphql` Gitbook](https://dillonkearns.gitbooks.io/elm-graphql/content/)
 * [A Beginner's Guide to GraphQL with Elm](https://medium.com/@zenitram.oiram/a-beginners-guide-to-graphql-with-elm-315b580f0aad) by [@martimatix](https://github.com/martimatix)
 * [Graphqelm: Optional Arguments in a Language Without Optional Arguments](https://medium.com/@zenitram.oiram/graphqelm-optional-arguments-in-a-language-without-optional-arguments-d8074ca3cf74) by [@martimatix](https://github.com/martimatix)
+* [Compehensive tutorial by the Hasura Team](https://learn.hasura.io/graphql/elm-graphql/introduction)
 
 If you're wondering why code is generated a certain way, you're likely to find an answer in the [Frequently Asked Questions (FAQ)](https://github.com/dillonkearns/elm-graphql/blob/master/FAQ.md).
 


### PR DESCRIPTION
Added recently by the Hasura team https://github.com/hasura/graphql-engine/pull/2427
It's very detailed and includes everything from querying, deleting, mutating and even subscriptions.