### PR TITLE
Add .fromResult to OptionalArgument

### DIFF
--- a/src/Graphql/OptionalArgument.elm
+++ b/src/Graphql/OptionalArgument.elm
@@ -1,5 +1,6 @@
 module Graphql.OptionalArgument exposing
     ( OptionalArgument(..)
+    , fromResult
     , fromMaybe
     , fromMaybeWithNull
     , map
@@ -8,6 +9,7 @@ module Graphql.OptionalArgument exposing
 {-|
 
 @docs OptionalArgument
+@docs fromResult
 @docs fromMaybe
 @docs fromMaybeWithNull
 @docs map
@@ -67,6 +69,23 @@ fromMaybe maybeValue =
             Present value
 
         Nothing ->
+            Absent
+
+
+{-| Convert a `Result` to an OptionalArgument.
+
+    fromResult (Ok a) == Present a
+
+    FromResult (Err _) == Absent
+
+-}
+fromResult : Result error value -> OptionalArgument value
+fromResult result =
+    case result of
+        Ok value ->
+            Present value
+
+        Err _ ->
             Absent
 
 


### PR DESCRIPTION
Hello Dillon!

I've been using a lot this helper and I think it makes sense that this lives in this library along with `fromMaybe`. Do you think it makes sense? Is almost the same just from a result haha

#### My use case
I'm using a field in my model to store the `date` picked in a form as String (to avoid parsing/decoding with the event). So, when I need to build the query, I need to transform `String->Time.posix`. I use https://package.elm-lang.org/packages/rtfeldman/elm-iso8601-date-strings/latest/Iso8601#toTime which returns a `Result`.

I think as building queries with `.fromMaybe`, is a nice to have `.fromResult`? To cover both types of conversions when using optional arguments.