### PR TITLE
Small performance improvement

### DIFF
--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -107,8 +107,8 @@ serializeChildren : Maybe Int -> List RawField -> String
 serializeChildren indentationLevel children =
     children
         |> nonemptyChildren
-        |> List.indexedMap
-            (\index field ->
+        |> List.map
+            (\field ->
                 serialize (alias field) (indentationLevel |> Maybe.map ((+) 1)) field
             )
         |> List.filterMap identity


### PR DESCRIPTION
No reason to generate `index` when it's not being used. `indexedMap` traverses the list twice: once to compute the indeces and once to do the actual mapping.