### PR TITLE
fix type collision in readme's first code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ query =
     Query.human { id = Id "1001" } humanSelection
 
 
-type alias AnotherHuman =
+type alias HumanData =
     { name : String
     , homePlanet : Maybe String
     }

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ type alias HumanData =
 
 humanSelection : SelectionSet Human StarWars.Object.Human
 humanSelection =
-    SelectionSet.map2 AnotherHuman
+    SelectionSet.map2 HumanData
         Human.name
         Human.homePlanet
 ```

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ query =
     Query.human { id = Id "1001" } humanSelection
 
 
-type alias Human =
+type alias AnotherHuman =
     { name : String
     , homePlanet : Maybe String
     }
@@ -57,7 +57,7 @@ type alias Human =
 
 humanSelection : SelectionSet Human StarWars.Object.Human
 humanSelection =
-    SelectionSet.map2 Human
+    SelectionSet.map2 AnotherHuman
         Human.name
         Human.homePlanet
 ```


### PR DESCRIPTION
There might be better fixes here — `QueryHuman` and `Human`, perhaps. 