### PR TITLE
Handle normalization for field names that are only underscores.

### DIFF
--- a/generator/src/Graphql/Generator/Normalize.elm
+++ b/generator/src/Graphql/Generator/Normalize.elm
@@ -15,14 +15,14 @@ normalizeIfElmReserved name =
         name
 
 
-underscores : String -> { leading : String, trailing : String, remaining : String }
+underscores : String -> { leading : String, trailing : String, remaining : Maybe String }
 underscores string =
     let
         regexFromString =
             Regex.fromString >> Maybe.withDefault Regex.never
     in
     case Regex.find (regexFromString "^(_*)([^_]?.*[^_]?)(_*)$") string |> List.head |> Maybe.map .submatches of
-        Just [ leading, Just remaining, trailing ] ->
+        Just [ leading, remaining, trailing ] ->
             { leading = Maybe.withDefault "" leading
             , trailing = Maybe.withDefault "" trailing
             , remaining = remaining
@@ -57,17 +57,24 @@ capitalized name =
         group =
             underscores name
     in
-    (if isAllUpper group.remaining then
-        group.remaining
-            |> String.toLower
-            |> String.Extra.classify
+    case group.remaining of
+        Nothing ->
+            "underscore"
+                ++ group.leading
+                ++ group.trailing
 
-     else
-        group.remaining
-            |> capitilize
-    )
-        ++ group.leading
-        ++ group.trailing
+        Just remaining ->
+            (if isAllUpper remaining then
+                remaining
+                    |> String.toLower
+                    |> String.Extra.classify
+
+             else
+                remaining
+                    |> capitilize
+            )
+                ++ group.leading
+                ++ group.trailing
 
 
 decapitalized : String -> String

--- a/generator/tests/Generator/NormalizeTests.elm
+++ b/generator/tests/Generator/NormalizeTests.elm
@@ -12,6 +12,14 @@ all =
             \() ->
                 Normalize.decapitalized "validCamelCaseName"
                     |> Expect.equal "validCamelCaseName"
+        , test "adds the word 'underscore' in front a single _ to make it a valid identifier" <|
+            \() ->
+                Normalize.decapitalized "_"
+                    |> Expect.equal "underscore_"
+        , test "adds the word 'underscore' in front of underscore-only names with multiple underscores" <|
+            \() ->
+                Normalize.decapitalized "__"
+                    |> Expect.equal "underscore__"
         , test "leaves valid snake_case names untouched" <|
             \() ->
                 Normalize.decapitalized "year_budget"


### PR DESCRIPTION
Normalize field names that are only `_`'s to valid Elm identifiers instead of stalling the CLI.

`_` is valid for assignments in Elm, but not for reading values. You can't read from `_`, they're just thrown away. So this is the normalization strategy now with this PR:

* `_` => `underscore_`
* `__` => `underscore__`

Fixes #285.