### PR TITLE
Fix typo in generated documentation

### DIFF
--- a/generator/src/Graphql/Generator/Enum.elm
+++ b/generator/src/Graphql/Generator/Enum.elm
@@ -66,7 +66,7 @@ list =
 enumToString : ClassCaseName -> List EnumValue -> String
 enumToString enumName enumValues =
     interpolate
-        """{-| Convert from the union type representating the Enum to a string that the GraphQL server will recognize.
+        """{-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : {0} -> String
 toString enum =


### PR DESCRIPTION
I don't know how to do this ( / run them), but the end-to-end tests and the examples should be updated, as I saw this typo a lot in there.

Let me know how I can do that if you wish for me to do that.

Have a good day :)