### PR TITLE
Remove reference to mutation in documentation of `RootSubscription`.

### DIFF
--- a/src/Graphql/Operation.elm
+++ b/src/Graphql/Operation.elm
@@ -23,8 +23,9 @@ type RootMutation
     = RootMutation
 
 
-{-| Type for top-level mutations which can be sent using functions
-from `Graphql.Http`.
+{-| Type for top-level subscriptions. Subscriptions use WebSockets, for which Elm needs ports. See
+https://github.com/dillonkearns/elm-graphql/blob/master/examples/subscription/Main.elm for an example of using
+`elm-graphql` subscriptions with ports.
 -}
 type RootSubscription
     = RootSubscription


### PR DESCRIPTION
Replace with subscription-specific information.