### PR TITLE
Integrate Murmur3 module

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -18,7 +18,6 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "Skinney/murmur3": "2.0.8 <= v < 3.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm/http": "2.0.0 <= v < 3.0.0",
         "elm/json": "1.1.1 <= v < 2.0.0",

--- a/ete_tests/elm.json
+++ b/ete_tests/elm.json
@@ -8,7 +8,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.8",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",

--- a/examples/complex/elm.json
+++ b/examples/complex/elm.json
@@ -8,7 +8,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.8",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -7,7 +7,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.8",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",

--- a/examples/subscription/elm.json
+++ b/examples/subscription/elm.json
@@ -8,7 +8,6 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.8",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",

--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -1,10 +1,9 @@
 module Graphql.Document.Field exposing (hashedAliasName, serializeChildren)
 
 import Graphql.Document.Argument as Argument
+import Graphql.Document.Hash exposing (hashString)
 import Graphql.Document.Indent as Indent
 import Graphql.RawField exposing (RawField(..))
-import List.Extra
-import Murmur3
 
 
 hashedAliasName : RawField -> String
@@ -41,7 +40,7 @@ maybeAliasHash field =
                     |> String.concat
                     |> Just
     )
-        |> Maybe.map (Murmur3.hashString 0)
+        |> Maybe.map (hashString 0)
 
 
 alias : RawField -> Maybe String

--- a/src/Graphql/Document/Hash.elm
+++ b/src/Graphql/Document/Hash.elm
@@ -1,0 +1,125 @@
+module Graphql.Document.Hash exposing (hashString)
+
+{-| Murmur 3 hash function for hashing strings
+
+@docs hashString
+
+-}
+
+import Bitwise as Bit
+
+
+type alias HashData =
+    { shift : Int
+    , seed : Int
+    , hash : Int
+    , charsProcessed : Int
+    }
+
+
+c1 : Int
+c1 =
+    0xCC9E2D51
+
+
+c2 : Int
+c2 =
+    0x1B873593
+
+
+{-| Takes a seed and a string. Produces a hash (integer).
+Given the same seed and string, it will always produce the same hash.
+
+    hashString 1234 "Turn me into a hash" == 4138100590
+
+-}
+hashString : Int -> String -> Int
+hashString seed str =
+    str
+        |> String.foldl hashFold (HashData 0 seed 0 0)
+        |> finalize
+
+
+hashFold : Char -> HashData -> HashData
+hashFold c data =
+    let
+        res =
+            Char.toCode c
+                |> Bit.and 0xFF
+                |> Bit.shiftLeftBy data.shift
+                |> Bit.or data.hash
+    in
+    -- Using case-of instead of == avoids costly .cmp check
+    case data.shift of
+        24 ->
+            { shift = 0
+            , seed = mix data.seed res
+            , hash = 0
+            , charsProcessed = data.charsProcessed + 1
+            }
+
+        _ ->
+            { shift = data.shift + 8
+            , seed = data.seed
+            , hash = res
+            , charsProcessed = data.charsProcessed + 1
+            }
+
+
+mix : Int -> Int -> Int
+mix h1 k1 =
+    (k1
+        |> multiplyBy c1
+        |> rotlBy 15
+        |> multiplyBy c2
+        |> Bit.xor h1
+        |> rotlBy 13
+        |> multiplyBy 5
+    )
+        + 0xE6546B64
+
+
+finalize : HashData -> Int
+finalize data =
+    let
+        acc =
+            if data.hash /= 0 then
+                data.hash
+                    |> multiplyBy c1
+                    |> rotlBy 15
+                    |> multiplyBy c2
+                    |> Bit.xor data.seed
+
+            else
+                data.seed
+
+        h0 =
+            Bit.xor acc data.charsProcessed
+
+        h1 =
+            Bit.xor h0 (Bit.shiftRightZfBy 16 h0)
+                |> multiplyBy 0x85EBCA6B
+
+        h2 =
+            Bit.xor h1 (Bit.shiftRightZfBy 13 h1)
+                |> multiplyBy 0xC2B2AE35
+    in
+    Bit.xor h2 (Bit.shiftRightZfBy 16 h2)
+        |> Bit.shiftRightZfBy 0
+
+
+{-| 32-bit multiplication
+-}
+multiplyBy : Int -> Int -> Int
+multiplyBy b a =
+    (Bit.and a 0xFFFF * b) + Bit.shiftLeftBy 16 (Bit.and (Bit.shiftRightZfBy 16 a * b) 0xFFFF)
+
+
+{-| Given a 32bit int and an int representing a number of bit positions,
+returns the 32bit int rotated left by that number of positions.
+-}
+rotlBy : Int -> Int -> Int
+rotlBy b a =
+    Bit.or
+        (Bit.shiftLeftBy b a)
+        (Bit.shiftRightZfBy (32 - b) a)


### PR DESCRIPTION
Hi, there is a problem with a compilation of this library due to a missing dependency, as stated in [the Murmur3 repo](https://github.com/robinheghan/murmur3/issues/5).

Since we don't know if the repo is actively maintained, copying the Murmur3 module inside `elm-graphql` seems a good compromise. I would also evaluate alternatives like hashing libraries with smaller footprint