### PR TITLE
Fix reference to subscriptions example in the subscriptions docs

### DIFF
--- a/docs/Subscriptions-FAQ.md
+++ b/docs/Subscriptions-FAQ.md
@@ -1,5 +1,5 @@
 ## Is there an example?
-Yes, see https://github.com/dillonkearns/elm-graphql/tree/master/examples/src/subscription. If you don't use Absinthe, then your JavaScript code for the Ports will need to be changed out to use code for your specific server-side framework.
+Yes, see https://github.com/dillonkearns/elm-graphql/tree/master/examples/subscription. If you don't use Absinthe, then your JavaScript code for the Ports will need to be changed out to use code for your specific server-side framework.
 
 ## How do I connect to my GraphQL Server using a Subscription?
 `Query`s and `Mutation`s in GraphQL have some standards for how to be sent (either HTTP GET or POST). However, `Subscription`s are not as standardized. The transfer protocol is completely non-standard. The handshakes and such to initialize the subscription are completely specific to each server-side GraphQL framework.


### PR DESCRIPTION
The link to the subscriptions example in the subscriptions FAQ is currently broken, this PR aims to fix it!