### PR TITLE
Fix a minor bug in circular reference detection of deeply nested input objects

### DIFF
--- a/generator/src/Graphql/Generator/InputObjectLoops.elm
+++ b/generator/src/Graphql/Generator/InputObjectLoops.elm
@@ -44,7 +44,7 @@ fieldIsCircular_ visitedNames typeDefs inputObjectName fieldTypeRef =
                             not alreadyVisitedThis
                                 || isRecursive inputObjectName fields
                                 || List.any
-                                    (fieldIsCircular_ (inputObjectName :: visitedNames) typeDefs inputObjectName)
+                                    (fieldIsCircular_ (inputObjectName :: visitedNames) typeDefs name)
                                     (fields |> List.map .typeRef)
 
                         Nothing ->

--- a/generator/tests/Generator/InputObjectLoopsTests.elm
+++ b/generator/tests/Generator/InputObjectLoopsTests.elm
@@ -84,7 +84,7 @@ all =
                 ]
                     |> InputObjectLoops.any
                     |> Expect.equal True
-        , test "deeploy nested loops through list reference" <|
+        , test "deeply nested loops through list reference" <|
             \() ->
                 [ TypeDefinition (ClassCaseName.build "CircularInputObjectOne")
                     (InputObjectType [ field "CircularInputObjectTwo" "fieldNameOne" ])
@@ -115,6 +115,31 @@ all =
                     (InputObjectType [ field "ProductInput" "newProduct" ])
                     Nothing
                 , TypeDefinition (ClassCaseName.build "ProductInput")
+                    (InputObjectType [ scalarField "name" ])
+                    Nothing
+                ]
+                    |> InputObjectLoops.any
+                    |> Expect.equal False
+        , test "extremely deeply nested through mixed references non-circular" <|
+            \() ->
+                [ TypeDefinition (ClassCaseName.build "InputTypeOne")
+                    (InputObjectType
+                        [ fieldListRef "InputTypeTwo" "typeTwos" ]
+                    )
+                    Nothing
+                , TypeDefinition (ClassCaseName.build "InputTypeTwo")
+                    (InputObjectType [ fieldListRef "InputTypeThree" "typeThrees" ])
+                    Nothing
+                , TypeDefinition (ClassCaseName.build "InputTypeThree")
+                    (InputObjectType [ fieldListRef "InputTypeFour" "typeFours" ])
+                    Nothing
+                , TypeDefinition (ClassCaseName.build "InputTypeFour")
+                    (InputObjectType [ field "InputTypeFive" "typeFive" ])
+                    Nothing
+                , TypeDefinition (ClassCaseName.build "InputTypeFive")
+                    (InputObjectType [ field "InputTypeSix" "typeSix" ])
+                    Nothing
+                , TypeDefinition (ClassCaseName.build "InputTypeSix")
                     (InputObjectType [ scalarField "name" ])
                     Nothing
                 ]


### PR DESCRIPTION
# Issue

When generating input object types with elm-graphql, some input objects get incorrectly flagged as containing loops, and get wrapped in a custom type.

Reference issue: https://github.com/dillonkearns/elm-graphql/issues/33

# Steps to repro

Create an input object type that contains at least 3 layers of other input objects.

Example (in graphql schema notation):
```graphql
input TypeOne {
  typeTwo: TypeTwo!
}
input TypeTwo {
  typeThree: TypeThree!
}
input TypeThree {
  typeFour: TypeFour!
}
input TypeFour {
  name: String!
}
```

Generate this schema using elm-graphql. `TypeOne` will be generated as:
```elm
type alias TypeOneRaw =
    { typeTwo = TypeTwo }

type TypeOne
    = TypeOne TypeOneRaw
```
# Root Cause 

The bug originates when we descend down the type trees to inspect the fields of the first input object that are input objects themselves. We correctly push the first input object's name onto "visitedClasses", but also pass the first input object's name as the currently evaluating name in the next loop of the recursion, when it should instead be the second layer child that we're checking.

# Fix

This PR updates the logic to pass the correct currently evaluation input object's name, and adds a test to guard against regressions.