### PR TITLE
Update (and fix) the domain for graphql specification links

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Github issue to discuss!
 
 I would like to investigate generating helpers to make pagination simpler
 for Connections (based on the
-[Relay Cursor Connections Specification](https://facebook.github.io/relay/graphql/connections.htm)).
+[Relay Cursor Connections Specification](https://relay.dev/graphql/connections.htm)).
 If you have ideas on this chime in on [this thread](https://github.com/dillonkearns/elm-graphql/issues/29).
 
 See [the full roadmap on Trello](https://trello.com/b/BCIWtZeL/dillonkearns-elm-graphql).

--- a/generator/src/Graphql/Generator/Decoder.elm
+++ b/generator/src/Graphql/Generator/Decoder.elm
@@ -135,10 +135,10 @@ generateEncoder_ context forInputObject (Type.TypeReference referrableType isNul
             MyDebug.crash "I don't expect to see object references as argument types."
 
         Type.InterfaceRef interfaceName ->
-            MyDebug.crash "Interfaces are never valid inputs http://facebook.github.io/graphql/October2016/#sec-Interfaces"
+            MyDebug.crash "Interfaces are never valid inputs https://spec.graphql.org/October2016/#sec-Interfaces"
 
         Type.UnionRef _ ->
-            MyDebug.crash "Unions are never valid inputs http://facebook.github.io/graphql/October2016/#sec-Unions"
+            MyDebug.crash "Unions are never valid inputs https://spec.graphql.org/October2016/#sec-Unions"
 
         Type.EnumRef enumName ->
             interpolate ("(Encode.enum {0})" ++ isNullableString)

--- a/src/Graphql/Http/GraphqlError.elm
+++ b/src/Graphql/Http/GraphqlError.elm
@@ -19,7 +19,7 @@ constraint that the schema doesn't specify, or 2) when your generated code is
 out of date with the schema.
 
 See the
-[Errors section in the GraphQL spec](http://facebook.github.io/graphql/October2016/#sec-Errors)
+[Errors section in the GraphQL spec](https://spec.graphql.org/October2016/#sec-Errors)
 for more details about GraphQL errors.
 
 -}
@@ -31,11 +31,11 @@ type alias GraphqlError =
 
 
 {-| Represents the `data` field in cases where there is an error present, see
-[the error section in the GraphQL spec](http://facebook.github.io/graphql/October2016/#sec-Data).
+[the error section in the GraphQL spec](https://spec.graphql.org/October2016/#sec-Data)
 If the decoder succeeds you will end up with `ParsedData`. If it fails, you
 will get an `UnparsedData` with a `Json.Decode.Value` containing the raw, undecoded
 `data` field. You're likely to end up with `UnparsedData` since
-[GraphQL will return `null` if there is an error on a non-nullable field](http://facebook.github.io/graphql/October2016/#sec-Errors-and-Non-Nullability)
+[GraphQL will return `null` if there is an error on a non-nullable field](https://spec.graphql.org/October2016/#sec-Errors-and-Non-Nullability)
 , which will cause the decode pipeline to fail and give you `UnparsedData`.
 -}
 type PossiblyParsedData parsed

--- a/src/Graphql/OptionalArgument.elm
+++ b/src/Graphql/OptionalArgument.elm
@@ -43,7 +43,7 @@ An optional argument can be either present, absent, or null, so using a Maybe do
 fully capture the GraphQL concept of an optional argument. For example, you could have
 a mutation that deletes an entry if a null argument is provided, or does nothing if
 the argument is absent. See
-[The official GraphQL spec section on null](http://facebook.github.io/graphql/October2016/#sec-Null-Value)
+[The official GraphQL spec section on null](https://spec.graphql.org/October2016/#sec-Null-Value)
 for details.
 
 -}


### PR DESCRIPTION
It looks like the content on facebook.github.io was split over several
domains at some point, with the `/graphql` namespace moving over to
spec.graphql.org, and the `/relay` namespace moving to relay.dev.

This PR updates all references to facebook.github.io to the proper
documentation domain.