### PR TITLE
Add support for the "extensions" key on errors

### DIFF
--- a/src/Graphql/Http/GraphqlError.elm
+++ b/src/Graphql/Http/GraphqlError.elm
@@ -19,7 +19,7 @@ constraint that the schema doesn't specify, or 2) when your generated code is
 out of date with the schema.
 
 See the
-[Errors section in the GraphQL spec](http://facebook.github.io/graphql/October2016/#sec-Errors)
+[Errors section in the GraphQL spec](https://spec.graphql.org/June2018/#sec-Errors)
 for more details about GraphQL errors.
 
 -}
@@ -27,6 +27,7 @@ type alias GraphqlError =
     { message : String
     , locations : Maybe (List Location)
     , details : Dict String Decode.Value
+    , extensions : Maybe (Dict String Decode.Value)
     }
 
 
@@ -47,13 +48,14 @@ type PossiblyParsedData parsed
 -}
 decoder : Decoder (List GraphqlError)
 decoder =
-    Decode.map3 GraphqlError
+    Decode.map4 GraphqlError
         (Decode.field "message" Decode.string)
         (Decode.maybe (Decode.field "locations" (Decode.list locationDecoder)))
         (Decode.dict Decode.value
             |> Decode.map (Dict.remove "message")
             |> Decode.map (Dict.remove "locations")
         )
+        (Decode.maybe (Decode.field "extensions" (Decode.dict Decode.value)))
         |> Decode.list
         |> Decode.field "errors"
 

--- a/tests/Http/GraphqlErrorTests.elm
+++ b/tests/Http/GraphqlErrorTests.elm
@@ -19,6 +19,7 @@ all =
                             [ { message = "You must provide a `first` or `last` value to properly paginate the `releases` connection."
                               , locations = Just [ { line = 4, column = 5 } ]
                               , details = Dict.empty
+                              , extensions = Nothing
                               }
                             ]
                         )
@@ -32,6 +33,7 @@ all =
                             [ { message = "Something went wrong while executing your query. Please include `94FE:5EA5:458434C:62871CD:5A44024B` when reporting this issue."
                               , locations = Nothing
                               , details = Dict.fromList []
+                              , extensions = Nothing
                               }
                             ]
                         )
@@ -48,7 +50,60 @@ all =
                             [ { message = "Something went wrong while executing your query. Please include `94FE:5EA5:458434C:62871CD:5A44024B` when reporting this issue."
                               , locations = Nothing
                               , details = Dict.fromList []
+                              , extensions = Nothing
                               }
                             ]
                         )
+        , test "error with extensions" <|
+            \() ->
+                """{"data":null,"errors":[{"message":"Something went wrong while executing your query","extensions":{"code": "CAN_NOT_FETCH_BY_ID","context":{"severity":"fatal"}}}]}
+                  """
+                    |> Json.Decode.decodeString GraphqlError.decoder
+                    |> Result.map (List.map decodeExtensions)
+                    |> Expect.equal
+                        (Ok
+                            [ Ok
+                                { code = "CAN_NOT_FETCH_BY_ID"
+                                , context =
+                                    { severity = "fatal" }
+                                }
+                            ]
+                        )
         ]
+
+
+type alias ErrorExtensions =
+    { code : String
+    , context : ErrorContext
+    }
+
+
+type alias ErrorContext =
+    { severity : String }
+
+
+decodeExtensions : GraphqlError.GraphqlError -> Result String ErrorExtensions
+decodeExtensions error =
+    case error.extensions of
+        Just extensions ->
+            let
+                codeResult =
+                    Dict.get "code" extensions
+                        |> Result.fromMaybe "no code"
+                        |> Result.andThen (Json.Decode.decodeValue Json.Decode.string >> Result.mapError Json.Decode.errorToString)
+
+                contextResult =
+                    Dict.get "context" extensions
+                        |> Result.fromMaybe "no context"
+                        |> Result.andThen (Json.Decode.decodeValue contextDecoder >> Result.mapError Json.Decode.errorToString)
+            in
+            Result.map2 ErrorExtensions codeResult contextResult
+
+        Nothing ->
+            Err "no extensions"
+
+
+contextDecoder : Json.Decode.Decoder ErrorContext
+contextDecoder =
+    Json.Decode.map ErrorContext
+        (Json.Decode.field "severity" Json.Decode.string)


### PR DESCRIPTION
The latest (published) graphql spec standardized an `extensions` key in the response format of graphql errors for optionally sending additional information about the error. The value of the extensions key is required to be a map, but beyond that there is no additional specification.

https://spec.graphql.org/June2018/#sec-Errors

This PR adds support for graphql error extensions to the `Graphql.Http.GraphqlError.GraphqlError` record in the form of a `Maybe (Dict String Json.Decode.Value)` field, allowing users to handle the values however they please.