### PR TITLE
Merge composite children

### DIFF
--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -131,12 +131,12 @@ mergedFields children =
         mergeThing =
             mergeFields children
     in
-    (mergeThing.leaves |> List.map leafToField)
+    (mergeThing.leaves |> Dict.values |> List.map leafToField)
         ++ (mergeThing.composites |> Dict.values |> List.map compositeToField)
 
 
 type alias MergedFields =
-    { leaves : List ( { typeString : String, fieldName : String }, List Argument )
+    { leaves : Dict String ( { typeString : String, fieldName : String }, List Argument )
     , composites : Dict String ( { name : String, args : List Argument }, List RawField )
     }
 
@@ -176,11 +176,18 @@ mergeFields rawFields =
                         }
 
                     Leaf info args ->
-                        { leaves = ( info, args ) :: leaves
+                        { leaves =
+                            leaves
+                                |> Dict.update (hashedAliasName field)
+                                    (\maybeChildrenSoFar ->
+                                        maybeChildrenSoFar
+                                            |> Maybe.withDefault ( info, args )
+                                            |> Just
+                                    )
                         , composites = composites
                         }
             )
-            { leaves = []
+            { leaves = Dict.empty
             , composites = Dict.empty
             }
 

--- a/src/Graphql/Document/Field.elm
+++ b/src/Graphql/Document/Field.elm
@@ -3,6 +3,7 @@ module Graphql.Document.Field exposing (hashedAliasName, serializeChildren)
 import Graphql.Document.Argument as Argument
 import Graphql.Document.Hash exposing (hashString)
 import Graphql.Document.Indent as Indent
+import Graphql.Internal.Builder.Argument exposing (Argument)
 import Graphql.RawField exposing (RawField(..))
 
 
@@ -106,6 +107,7 @@ serializeChildren : Maybe Int -> List RawField -> String
 serializeChildren indentationLevel children =
     children
         |> nonemptyChildren
+        |> mergeChildren
         |> List.map
             (\field ->
                 serialize (alias field) (indentationLevel |> Maybe.map ((+) 1)) field
@@ -119,6 +121,29 @@ serializeChildren indentationLevel children =
                 Nothing ->
                     " "
             )
+
+
+mergeChildren : List RawField -> List RawField
+mergeChildren fields =
+    case fields of
+        [ Composite name1 args1 fields1, Composite name2 args2 fields2 ] ->
+            if name1 == name2 && hasSameArgs args1 args2 then
+                [ Composite name1 args1 (fields1 ++ fields2) ]
+
+            else
+                fields
+
+        _ ->
+            fields
+
+
+hasSameArgs : List Argument -> List Argument -> Bool
+hasSameArgs args1 args2 =
+    if List.isEmpty args1 && List.isEmpty args2 then
+        True
+
+    else
+        False
 
 
 nonemptyChildren : List RawField -> List RawField

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -51,7 +51,7 @@ all =
                         ]
                     ]
                     |> Graphql.Document.serializeQueryForUrl
-                    |> Expect.equal "{topLevel{avatar0:avatar avatar0:avatar}}"
+                    |> Expect.equal "{topLevel{avatar0:avatar}}"
         , test "multiple top-level" <|
             \() ->
                 document
@@ -60,8 +60,8 @@ all =
                     ]
                     |> Graphql.Document.serializeQuery
                     |> Expect.equal """query {
-  labels0: labels
   avatar0: avatar
+  labels0: labels
 }"""
         , test "duplicate top-level fields" <|
             \() ->
@@ -71,7 +71,6 @@ all =
                     ]
                     |> Graphql.Document.serializeQuery
                     |> Expect.equal """query {
-  avatar0: avatar
   avatar0: avatar
 }"""
         , test "duplicate nested fields" <|
@@ -86,7 +85,6 @@ all =
                     |> Graphql.Document.serializeQuery
                     |> Expect.equal """query {
   topLevel {
-    avatar0: avatar
     avatar0: avatar
   }
 }"""
@@ -180,8 +178,8 @@ all =
                         |> Expect.equal """query {
   me {
     firstName0: firstName
-    middleName0: middleName
     lastName0: lastName
+    middleName0: middleName
   }
 }"""
             , test "different arguments are not merged" <|
@@ -203,6 +201,36 @@ all =
   me1529416052: me(id: 456) {
     lastName0: lastName
   }
+  me3003759287: me(id: 123) {
+    firstName0: firstName
+  }
+}"""
+            , test "identical leaves are de-duped" <|
+                \() ->
+                    document
+                        [ leaf "version" []
+                        , leaf "version" []
+                        ]
+                        |> Graphql.Document.serializeQuery
+                        |> Expect.equal """query {
+  version0: version
+}"""
+            , test "identical leaves from a merged Composite parent de-duped" <|
+                \() ->
+                    document
+                        [ Composite "me"
+                            [ Graphql.Internal.Builder.Argument.Argument "id" (Graphql.Internal.Encode.int 123)
+                            ]
+                            [ leaf "firstName" []
+                            ]
+                        , Composite "me"
+                            [ Graphql.Internal.Builder.Argument.Argument "id" (Graphql.Internal.Encode.int 123)
+                            ]
+                            [ leaf "firstName" []
+                            ]
+                        ]
+                        |> Graphql.Document.serializeQuery
+                        |> Expect.equal """query {
   me3003759287: me(id: 123) {
     firstName0: firstName
   }

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -140,4 +140,25 @@ all =
                         |> Graphql.Document.serializeQueryForUrlWithOperationName "Avatar"
                         |> Expect.equal """query Avatar {avatar0:avatar}"""
             ]
+        , describe "sibling leaves with same composite parent"
+            [ test "simple case" <|
+                \() ->
+                    document
+                        [ Composite "me"
+                            []
+                            [ leaf "firstName" []
+                            ]
+                        , Composite "me"
+                            []
+                            [ leaf "lastName" []
+                            ]
+                        ]
+                        |> Graphql.Document.serializeQuery
+                        |> Expect.equal """query {
+  me {
+    firstName0: firstName
+    lastName0: lastName
+  }
+}"""
+            ]
         ]

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -60,8 +60,8 @@ all =
                     ]
                     |> Graphql.Document.serializeQuery
                     |> Expect.equal """query {
-  avatar0: avatar
   labels0: labels
+  avatar0: avatar
 }"""
         , test "duplicate top-level fields" <|
             \() ->
@@ -200,11 +200,11 @@ all =
                         ]
                         |> Graphql.Document.serializeQuery
                         |> Expect.equal """query {
-  me3003759287: me(id: 123) {
-    firstName0: firstName
-  }
   me1529416052: me(id: 456) {
     lastName0: lastName
+  }
+  me3003759287: me(id: 123) {
+    firstName0: firstName
   }
 }"""
             ]

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -160,5 +160,52 @@ all =
     lastName0: lastName
   }
 }"""
+            , test "merges 3 with no args" <|
+                \() ->
+                    document
+                        [ Composite "me"
+                            []
+                            [ leaf "firstName" []
+                            ]
+                        , Composite "me"
+                            []
+                            [ leaf "middleName" []
+                            ]
+                        , Composite "me"
+                            []
+                            [ leaf "lastName" []
+                            ]
+                        ]
+                        |> Graphql.Document.serializeQuery
+                        |> Expect.equal """query {
+  me {
+    firstName0: firstName
+    middleName0: middleName
+    lastName0: lastName
+  }
+}"""
+            , test "different arguments are not merged" <|
+                \() ->
+                    document
+                        [ Composite "me"
+                            [ Graphql.Internal.Builder.Argument.Argument "id" (Graphql.Internal.Encode.int 123)
+                            ]
+                            [ leaf "firstName" []
+                            ]
+                        , Composite "me"
+                            [ Graphql.Internal.Builder.Argument.Argument "id" (Graphql.Internal.Encode.int 456)
+                            ]
+                            [ leaf "lastName" []
+                            ]
+                        ]
+                        |> Graphql.Document.serializeQuery
+                        |> Expect.equal """query {
+  me3003759287: me(id: 123) {
+    firstName0: firstName
+  }
+  me1529416052: me(id: 456) {
+    lastName0: lastName
+  }
+}"""
             ]
         ]

--- a/tests/DocumentTests.elm
+++ b/tests/DocumentTests.elm
@@ -140,8 +140,8 @@ all =
                         |> Graphql.Document.serializeQueryForUrlWithOperationName "Avatar"
                         |> Expect.equal """query Avatar {avatar0:avatar}"""
             ]
-        , describe "sibling leaves with same composite parent"
-            [ test "simple case" <|
+        , describe "merge composite fields"
+            [ test "without arguments" <|
                 \() ->
                     document
                         [ Composite "me"


### PR DESCRIPTION
Fields will have collisions if there is more than one with the same field name or field alias. This ensures that composite fields with the same field name or field alias are merged into one composite.

Fixes #495.