### PR TITLE
Add fallback for fields that contain objects

### DIFF
--- a/src/Graphql/Internal/Builder/Object.elm
+++ b/src/Graphql/Internal/Builder/Object.elm
@@ -15,6 +15,7 @@ import Graphql.Internal.Builder.Argument exposing (Argument)
 import Graphql.RawField exposing (RawField)
 import Graphql.SelectionSet exposing (FragmentSelectionSet(..), SelectionSet(..))
 import Json.Decode as Decode exposing (Decoder)
+import Json.Encode as Encode
 import String.Interpolate exposing (interpolate)
 
 
@@ -36,6 +37,7 @@ scalarDecoder =
                         False ->
                             "false"
                 )
+        , Decode.value |> Decode.map (Encode.encode 0)
         ]
 
 

--- a/src/Graphql/Internal/Builder/Object.elm
+++ b/src/Graphql/Internal/Builder/Object.elm
@@ -25,8 +25,6 @@ scalarDecoder : Decoder String
 scalarDecoder =
     Decode.oneOf
         [ Decode.string
-        , Decode.float |> Decode.map String.fromFloat
-        , Decode.int |> Decode.map String.fromInt
         , Decode.bool
             |> Decode.map
                 (\bool ->


### PR DESCRIPTION
closes #568

The resulting string can be decoded as needed to extract information from the field.

This feature is needed for a corner case in our codebase where an history endpoint needs to behave dynamically in terms of the data it sends.  