### PR TITLE
Allow skipping validation of custom scalar codecs.

### DIFF
--- a/generator/src/Main.elm
+++ b/generator/src/Main.elm
@@ -67,6 +67,7 @@ type alias UrlArgs =
     , headers : Dict.Dict String String
     , scalarCodecsModule : Maybe ModuleName
     , skipElmFormat : Bool
+    , skipValidation : Bool
     }
 
 
@@ -76,6 +77,7 @@ type alias FileArgs =
     , outputPath : String
     , scalarCodecsModule : Maybe ModuleName
     , skipElmFormat : Bool
+    , skipValidation : Bool
     }
 
 
@@ -114,6 +116,7 @@ program =
                     )
                 |> with scalarCodecsOption
                 |> with skipElmFormatOption
+                |> with skipScalarCodecValidationOption
                 |> OptionsParser.withDoc "generate files based on the schema at `url`"
                 |> OptionsParser.map FromUrl
             )
@@ -124,6 +127,7 @@ program =
                 |> with outputPathOption
                 |> with scalarCodecsOption
                 |> with skipElmFormatOption
+                |> with skipScalarCodecValidationOption
                 |> OptionsParser.map FromIntrospectionFile
             )
         |> Program.add
@@ -133,6 +137,7 @@ program =
                 |> with outputPathOption
                 |> with scalarCodecsOption
                 |> with skipElmFormatOption
+                |> with skipScalarCodecValidationOption
                 |> OptionsParser.map FromSchemaFile
             )
 
@@ -148,6 +153,11 @@ scalarCodecsOption =
 skipElmFormatOption : Option.Option Bool Bool Option.BeginningOption
 skipElmFormatOption =
     Option.flag "skip-elm-format"
+
+
+skipScalarCodecValidationOption : Option.Option Bool Bool Option.BeginningOption
+skipScalarCodecValidationOption =
+    Option.flag "skip-validation"
 
 
 outputPathOption : Option.Option (Maybe String) String Option.BeginningOption
@@ -183,7 +193,12 @@ init flags msg =
                 , outputPath = options.outputPath
                 , baseModule = options.base
                 , headers = options.headers |> Json.Encode.dict identity Json.Encode.string
-                , customDecodersModule = options.scalarCodecsModule |> Maybe.map ModuleName.toString
+                , customDecodersModule =
+                    if options.skipValidation then
+                        Nothing
+
+                    else
+                        options.scalarCodecsModule |> Maybe.map ModuleName.toString
                 }
             )
 
@@ -193,7 +208,12 @@ init flags msg =
                 { introspectionFilePath = options.file
                 , outputPath = options.outputPath
                 , baseModule = options.base
-                , customDecodersModule = options.scalarCodecsModule |> Maybe.map ModuleName.toString
+                , customDecodersModule =
+                    if options.skipValidation then
+                        Nothing
+
+                    else
+                        options.scalarCodecsModule |> Maybe.map ModuleName.toString
                 }
             )
 
@@ -203,7 +223,12 @@ init flags msg =
                 { schemaFilePath = options.file
                 , outputPath = options.outputPath
                 , baseModule = options.base
-                , customDecodersModule = options.scalarCodecsModule |> Maybe.map ModuleName.toString
+                , customDecodersModule =
+                    if options.skipValidation then
+                        Nothing
+
+                    else
+                        options.scalarCodecsModule |> Maybe.map ModuleName.toString
                 }
             )
 


### PR DESCRIPTION
At Crowdstrike we have a build setup that uses Bazel. Much like in `Make` build target take input files and produce output files. If an input file changes, the the target must be rebuilt.

In order for elm-graphql to generate files - when there is are custom scalar codecs - it will validate the custom scalar codec Elm file to see if the definitions match the scalar types in the GQL schema.

This becomes a problem because since the custom Elm file can import other parts of the codebase. Effectively the entire Elm codebase becomes a dependency for the "GQL API client generation" build step. So, if any Elm file is changed, the client must be regenerated! This in our case adds ca. 8s to each build iteration, which is not cool in a dev environment.

This PR adds CLI flag `--skip-validation` which disables the validation step. This solves our problem because the code generation no longer depends on any Elm source in our project codebase anymore.

This will obviously mean that you will not get errors before compilation of the entire project. But the errors will still be caught by the compiler, though in a less reader-friendly way. We think this is acceptable because adding `--skip-validation` is a very deliberate action.