### PR TITLE
Use Cli.Validate.regexWithMessage when validating module name

### DIFF
--- a/generator/elm.json
+++ b/generator/elm.json
@@ -6,7 +6,7 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "dillonkearns/elm-cli-options-parser": "3.0.1",
+            "dillonkearns/elm-cli-options-parser": "3.1.0",
             "elm/core": "1.0.5",
             "elm/json": "1.1.3",
             "elm/regex": "1.0.0",

--- a/generator/src/Main.elm
+++ b/generator/src/Main.elm
@@ -165,7 +165,7 @@ baseOption =
 
 validateModuleName : String -> Cli.Validate.ValidationResult
 validateModuleName =
-    Cli.Validate.regex "^[A-Z][A-Za-z_]*(\\.[A-Z][A-Za-z_]*)*$"
+    Cli.Validate.regexWithMessage "I expected this to be" "^[A-Z][A-Za-z_]*(\\.[A-Z][A-Za-z_]*)*$"
 
 
 type alias Flags =

--- a/generator/src/Main.elm
+++ b/generator/src/Main.elm
@@ -165,7 +165,7 @@ baseOption =
 
 validateModuleName : String -> Cli.Validate.ValidationResult
 validateModuleName =
-    Cli.Validate.regexWithMessage "I expected this to be" "^[A-Z][A-Za-z_]*(\\.[A-Z][A-Za-z_]*)*$"
+    Cli.Validate.regexWithMessage "I expected an Elm module name" "^[A-Z][A-Za-z_]*(\\.[A-Z][A-Za-z_]*)*$"
 
 
 type alias Flags =


### PR DESCRIPTION
Display validation message with an additional "I expected this to be" so the output becomes:


```
Validation errors:

Invalid `--scalar-codecs` option.
I expected this to be matching "^[A-Z][A-Za-z_]*(\.[A-Z][A-Za-z_]*)*$", but got 'src/CustomScalarCodecs'

```